### PR TITLE
Implement resolution truncation between scaling and refinement

### DIFF
--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -148,7 +148,7 @@ def compute_mr_difference_map(
         verbose=verbose,
         rbr_selections=rbr_phenix,
         off_labels=f"{Fon},{SigFon}",  # workaround for compatibility
-        mr_naming=True,
+        mr_on=True,
     )
 
     print(f"{time.strftime('%H:%M:%S')}: Running phenix.refine for the 'off' data...")
@@ -163,6 +163,7 @@ def compute_mr_difference_map(
         verbose=verbose,
         rbr_selections=rbr_phenix,
         off_labels=f"{Foff},{SigFoff}",
+        mr_off=True,
     )
 
     # from here down I just copied over the stuff from the normal version

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -19,6 +19,7 @@ from matchmaps._utils import (
     _rbr_selection_parser,
     _remove_waters,
     _restore_ligand_occupancy,
+    _validate_environment,
     phaser_wrapper,
 )
 
@@ -85,6 +86,8 @@ def compute_mr_difference_map(
         If omitted, the sensible built-in .eff template is used. If you need to change something,
         I recommend copying the template from the source code and editing that.
     """
+    
+    _validate_environment(ccp4=False)
 
     off_name = str(mtzoff.removesuffix(".mtz"))
     on_name = str(mtzon.removesuffix(".mtz"))

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -20,6 +20,7 @@ from matchmaps._utils import (
     _rbr_selection_parser,
     _renumber_waters,
     _ncs_align_and_subtract,
+    _validate_environment
 )
 
 
@@ -40,6 +41,8 @@ def compute_ncs_difference_map(
     refine_ncs_separately=False,
     eff=None,
 ):
+    _validate_environment(ccp4=False)
+    
     # make sure directories have a trailing slash!
     if input_dir[-1] != "/":
         input_dir = input_dir + "/"

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import glob
 import subprocess
 import time
 from functools import partial
@@ -96,6 +97,8 @@ def compute_realspace_difference_map(
 
     if output_dir[-1] != "/":
         output_dir = output_dir + "/"
+        
+    output_dir_contents = glob.glob(output_dir + "*")
 
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -113,7 +113,7 @@ def compute_realspace_difference_map(
         capture_output=(not verbose),
     )
     
-    #### now that scaleit has run, let's swap out the spacegroup from the scaled file
+    ## now that scaleit has run, let's swap out the spacegroup from the scaled file
     mtzon_scaled_py = rs.read_mtz(f'{output_dir}/{mtzon_scaled}')
     mtzon_original_py = rs.read_mtz(f'{input_dir}/{mtzon}')
     
@@ -123,10 +123,8 @@ def compute_realspace_difference_map(
     mtzon_scaled_py.write_mtz(f'{output_dir}/{mtzon_scaled_truecell}')
     
     mtzon = mtzon_scaled_truecell
-    
-    print('Did cell swapping!')
-    
-    #### done with cell swapping
+        
+    ## done with cell swapping
     
     pdboff = _handle_special_positions(pdboff, input_dir, output_dir)
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -108,12 +108,25 @@ def compute_realspace_difference_map(
         shell=True,
         capture_output=(not verbose),
     )
-
+    
+    #### now that scaleit has run, let's swap out the spacegroup from the scaled file
+    mtzon_scaled_py = rs.read_mtz(f'{output_dir}/{mtzon_scaled}')
+    mtzon_original_py = rs.read_mtz(f'{input_dir}/{mtzon}')
+    
+    mtzon_scaled_truecell = mtzon_scaled.removesuffix(".mtz") + "_truecell" + ".mtz"
+    
+    mtzon_scaled_py.cell = mtzon_original_py.cell
+    mtzon_scaled_py.write_mtz(f'{output_dir}/{mtzon_scaled_truecell}')
+    
+    mtzon = mtzon_scaled_truecell
+    
+    print('Did cell swapping!')
+    
+    #### done with cell swapping
+    
     pdboff = _handle_special_positions(pdboff, input_dir, output_dir)
 
     pdboff = _renumber_waters(pdboff, output_dir)
-
-    mtzon = mtzon_scaled
 
     print(f"{time.strftime('%H:%M:%S')}: Running phenix.refine for the 'on' data...")
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -19,6 +19,7 @@ from matchmaps._utils import (
     _rbr_selection_parser,
     _renumber_waters,
     # _clean_up_files,
+    _validate_environment
 )
 
 
@@ -83,6 +84,9 @@ def compute_realspace_difference_map(
         If omitted, the sensible built-in .eff template is used. If you need to change something,
         I recommend copying the template from the source code and editing that.
     """
+    
+    _validate_environment(ccp4=True)
+    
     off_name = str(mtzoff.removesuffix(".mtz"))
     on_name = str(mtzon.removesuffix(".mtz"))
 

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -844,34 +844,34 @@ def _quicknorm(array):
     return (array - array.mean()) / array.std()
 
 
-def _find_available_dirname(prefix):
-    existing = glob.glob(f"{prefix}_[0-9]*/")
+# def _find_available_dirname(prefix):
+#     existing = glob.glob(f"{prefix}_[0-9]*/")
 
-    if len(existing) == 0:
-        new_suffix = "0"
-    else:
-        n = max([int(s.split("_")[-1].removesuffix("/")) for s in existing])
-        new_suffix = f"{n+1}"
+#     if len(existing) == 0:
+#         new_suffix = "0"
+#     else:
+#         n = max([int(s.split("_")[-1].removesuffix("/")) for s in existing])
+#         new_suffix = f"{n+1}"
 
-    return new_suffix
+#     return new_suffix
 
-def _clean_up_files(output_dir, old_files):
+# def _clean_up_files(output_dir, old_files):
     
-    prefix='matchmapsfiles'
+#     prefix='matchmapsfiles'
 
-    n = _find_available_dirname(prefix)
-    cleanup_dir = f"{output_dir}/prefix_{n}"
+#     n = _find_available_dirname(prefix)
+#     cleanup_dir = f"{output_dir}/prefix_{n}"
 
-    os.mkdir(cleanup_dir)
+#     os.mkdir(cleanup_dir)
 
-    candidate_files = []
-    for suffix in ('eff', 'pdb', 'mtz', 'log', 'cif'):
-        candidate_files.append(glob.glob(output_dir + '*' + suffix))
+#     candidate_files = []
+#     for suffix in ('eff', 'pdb', 'mtz', 'log', 'cif'):
+#         candidate_files.append(glob.glob(output_dir + '*' + suffix))
         
-    files_to_move = list(filter(
-        lambda x: 
-            x not in old_files, 
-        candidate_files
-        )) 
-    
-    return
+#     files_to_move = list(filter(
+#         lambda x: 
+#             x not in old_files, 
+#         candidate_files
+#         )) 
+
+#     return

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -264,7 +264,8 @@ refinement {
         nickname += f"_{max(nums)+1}"
 
     # read in mtz to access cell parameters and spacegroup
-    mtz = rs.read_mtz((output_dir if (off_labels is None) else input_dir) + mtzon)
+    #mtz = rs.read_mtz((output_dir if (off_labels is None) else input_dir) + mtzon)
+    mtz = rs.read_mtz(output_dir + mtzon)
     cell_string = f"{mtz.cell.a} {mtz.cell.b} {mtz.cell.c} {mtz.cell.alpha} {mtz.cell.beta} {mtz.cell.gamma}"
     sg = mtz.spacegroup.short_name()
 
@@ -275,7 +276,8 @@ refinement {
         "sg": sg,
         "cell_parameters": cell_string,
         "pdb_input": output_dir + pdboff,
-        "mtz_input": (output_dir if (off_labels is None) else input_dir) + mtzon,
+        "mtz_input": output_dir + mtzon,
+        #"mtz_input": (output_dir if (off_labels is None) else input_dir) + mtzon,
         "nickname": output_dir + nickname,
     }
 

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -17,7 +17,27 @@ import gemmi
 import numpy as np
 import reciprocalspaceship as rs
 
+def _validate_environment(ccp4):
+    """
+    Check if the environment contains phenix (and if necessary, ccp4) and throw a helpful error if not
+    """
 
+    if shutil.which("phenix.refine") is None:
+        raise OSError(
+            "phenix is not active in your current environment. Please activate phenix and try again."
+            "\n"
+            "For more information, see https://rs-station.github.io/matchmaps/quickstart.html#additional-dependencies"
+        )
+        
+    if ccp4:
+        if shutil.which("scaleit") is None:
+            raise OSError(
+                "ccp4 is not active in your current environment. Please activate ccp4 and try again."
+                "\n"
+                "For more information, see https://rs-station.github.io/matchmaps/quickstart.html#additional-dependencies"
+            )
+    
+    
 def _rbr_selection_parser(rbr_selections):
     # end early and return nones if this feature isn't being used
     if rbr_selections is None:
@@ -163,11 +183,6 @@ def rigid_body_refinement_wrapper(
     rbr_selections=None,
     mr_naming=False,
 ):
-    # confirm that phenix is active in the command-line environment
-    if shutil.which("phenix.refine") is None:
-        raise OSError(
-            "Cannot find executable, phenix.refine. Please set up your phenix environment."
-        )
 
     if eff is None:
         eff_contents = """


### PR DESCRIPTION
This PR:

- corrects a previous bug/poor behavior where following scaling, the unit cell from the "off" data was used for both datasets. Now, following `SCALEIT`, the unit cell from the "on" mtz is manually restored.
- Following `SCALEIT`, both mtzs ("off" and "scaled on") are truncated to have matching resolution.
- various changes to the rigid-body refinement wrapper to ensure compatibility between all utilities.

I also continued work on the file cleanup functionality. This will be finished in a future PR which includes a more radical overhaul of how paths are handled.