### PR TITLE
Handle all filenames with `pathlib` 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,15 +65,41 @@ matchmaps --mtzoff apo_data.mtz Fobs SIGFobs \
     --pdboff apo.pdb \
     --ligands weird_solvent_1.cif weird_solvent_2.cif
 ```
+ 
+If you'd like read or write files from somewhere other than your current directory, you can! There are three ways to specify input files:
+ - Provide relative paths directly for all input files
+ - Provide only file names, and add the `--input-dir` option to specify where those files live. If you do this, the same `--input-dir` will be preprended to all filenames, so your files should all live in the same place.
+ - Provide absolute paths to input files. For any input supplied as an absolute path, the `--input-dir` will be ignored.
 
-If you'd like read or write files from somewhere other than your current directory, you can! Just use the `--input-dir` and `--output-dir` flags. However, note that 1) your input files should all live in the same directory, and 2) you **must** use these flags rather than supplying a long relative path directly as the filename. It is possible that long relative paths will be supported in a future release, but I can't promise that. An example:
+To direct output files to a specific directory, use the `--output-dir` flag. By default, all of the temporary files created by `matchmaps` will be deleted when the program finishes. Only the `.map` files described below are kept. If you would like to keep all files, you may additionally supply a `--keep-temp-files` directory, which will be created inside of `--output-dir`.
 
+### Examples 
+
+Supply an input directory:
 ```bash
 matchmaps --mtzoff apo_data.mtz Fobs SIGFobs \
     --mtzon bound_data.mtz Fobs SIGFobs \
     --pdboff apo.pdb \
     --input-dir analysis/matchmaps \
     --output-dir ../data/myproject
+```
+
+Supply relative inputs; keep all files:
+```bash
+matchmaps --mtzoff input_files/apo_data.mtz Fobs SIGFobs \
+    --mtzon input_files/bound_data.mtz Fobs SIGFobs \
+    --pdboff different_dir_with_input_files/apo.pdb \
+    --output-dir ../data/myproject \
+    --keep-temp-files mmfiles
+```
+
+Supply a mix of relative and absolute inputs:
+```bash
+matchmaps --mtzoff apo_data.mtz Fobs SIGFobs \
+    --mtzon bound_data.mtz Fobs SIGFobs \
+    --pdboff /complicated/absolute/path/to/apo.pdb \
+    --input-dir input_files \
+    --output-dir ../data/myproject \
 ```
 
 ## Other useful options

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -12,7 +12,6 @@ import reciprocalspaceship as rs
 
 from matchmaps._utils import (
     _handle_special_positions,
-    # align_grids_from_model_transform,
     make_floatgrid_from_mtz,
     rigid_body_refinement_wrapper,
     _realspace_align_and_subtract,
@@ -22,6 +21,7 @@ from matchmaps._utils import (
     _validate_environment,
     _validate_inputs,
     phaser_wrapper,
+    _clean_up_files,
 )
 
 
@@ -42,6 +42,7 @@ def compute_mr_difference_map(
     verbose=False,
     rbr_selections=None,
     eff=None,
+    keep_temp_files=None,
 ):
     """
     Compute a real-space difference map from mtzs in different spacegroups.
@@ -93,7 +94,7 @@ def compute_mr_difference_map(
     off_name = mtzoff.name.removesuffix(".mtz")
     on_name = mtzon.name.removesuffix(".mtz")
     
-    output_dir_contents = output_dir.glob("*")
+    output_dir_contents = list(output_dir.glob("*"))
 
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)
@@ -218,9 +219,9 @@ def compute_mr_difference_map(
                 on_as_stationary=on_as_stationary,
                 selection=selection,
             )
-    # print(f"{time.strftime('%H:%M:%S')}: Cleaning up files...")
+    print(f"{time.strftime('%H:%M:%S')}: Cleaning up files...")
 
-    # _clean_up_files()
+    _clean_up_files(output_dir, output_dir_contents, keep_temp_files)
 
     print(f"{time.strftime('%H:%M:%S')}: Done!")
 
@@ -366,6 +367,17 @@ def parse_arguments():
         default=None,
         help=("Custom .eff template for running phenix.refine. "),
     )
+    
+    parser.add_argument(
+        "--keep-temp-files",
+        "-k",
+        required=False,
+        default=None,
+        help=(
+            "Do not delete intermediate matchmaps files, but rather place them in the supplied directory. "
+            "This directory is created as a subdirectory of the supplied output-dir."
+        )
+    )
 
     return parser
 
@@ -406,6 +418,7 @@ def main():
         dmin=args.dmin,
         spacing=args.spacing,
         on_as_stationary=args.on_as_stationary,
+        keep_temp_files=args.keep_temp_files,
     )
 
     return

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -20,6 +20,7 @@ from matchmaps._utils import (
     _remove_waters,
     _restore_ligand_occupancy,
     _validate_environment,
+    _validate_inputs,
     phaser_wrapper,
 )
 
@@ -89,15 +90,10 @@ def compute_mr_difference_map(
     
     _validate_environment(ccp4=False)
 
-    off_name = str(mtzoff.removesuffix(".mtz"))
-    on_name = str(mtzon.removesuffix(".mtz"))
-
-    # make sure directories have a trailing slash!
-    if input_dir[-1] != "/":
-        input_dir = input_dir + "/"
-
-    if output_dir[-1] != "/":
-        output_dir = output_dir + "/"
+    off_name = mtzoff.name.removesuffix(".mtz")
+    on_name = mtzon.name.removesuffix(".mtz")
+    
+    output_dir_contents = output_dir.glob("*")
 
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)
@@ -106,7 +102,7 @@ def compute_mr_difference_map(
     # this is where scaling takes place in the usual pipeline, but that doesn't make sense with different-spacegroup inputs
     # side note: I need to test the importance of scaling even in the normal case!! Might be more artifact than good, who knows
 
-    pdboff = _handle_special_positions(pdboff, input_dir, output_dir)
+    pdboff = _handle_special_positions(pdboff, output_dir)
 
     # write this function as a wrapper around phenix.pdbtools
     # modified pdboff already moved to output_dir by _handle_special_positions
@@ -128,9 +124,8 @@ def compute_mr_difference_map(
 
     # TO-DO: fix ligand occupancies in pdb_mr_to_on
     edited_mr_pdb = _restore_ligand_occupancy(
-        pdb_to_be_restored=phaser_nickname + ".1.pdb",
+        pdb_to_be_restored= str(phaser_nickname) + ".1.pdb",
         original_pdb=pdboff,
-        # ligands=ligands,
         output_dir=output_dir,
     )
 
@@ -171,11 +166,11 @@ def compute_mr_difference_map(
 
     # read back in the files created by phenix
     # these have knowable names
-    mtzon = rs.read_mtz(f"{output_dir}/{nickname_on}_1.mtz")
-    mtzoff = rs.read_mtz(f"{output_dir}/{nickname_off}_1.mtz")
+    mtzon = rs.read_mtz(f"{nickname_on}_1.mtz")
+    mtzoff = rs.read_mtz(f"{nickname_off}_1.mtz")
 
-    pdbon = gemmi.read_structure(f"{output_dir}/{nickname_on}_1.pdb")
-    pdboff = gemmi.read_structure(f"{output_dir}/{nickname_off}_1.pdb")
+    pdbon = gemmi.read_structure(f"{nickname_on}_1.pdb")
+    pdboff = gemmi.read_structure(f"{nickname_off}_1.pdb")
 
     if dmin is None:
         dmin = max(
@@ -385,17 +380,26 @@ def main():
     if not os.path.exists(args.input_dir):
         raise ValueError(f"Input directory '{args.input_dir}' does not exist")
 
+    (input_dir, output_dir, ligands, mtzoff, mtzon, pdboff) = _validate_inputs(
+        args.input_dir,
+        args.output_dir,
+        args.ligands,
+        args.mtzoff[0],
+        args.mtzon[0],
+        args.pdboff,
+    )
+    
     compute_mr_difference_map(
-        pdboff=args.pdboff,
-        ligands=args.ligands,
-        mtzoff=args.mtzoff[0],
-        mtzon=args.mtzon[0],
+        pdboff=pdboff,
+        ligands=ligands,
+        mtzoff=mtzoff,
+        mtzon=mtzon,
         Foff=args.mtzoff[1],
         SigFoff=args.mtzoff[2],
         Fon=args.mtzon[1],
         SigFon=args.mtzon[2],
-        input_dir=args.input_dir,
-        output_dir=args.output_dir,
+        input_dir=input_dir,
+        output_dir=output_dir,
         verbose=args.verbose,
         rbr_selections=args.rbr_selections,
         eff=args.eff,

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -45,12 +45,7 @@ def compute_ncs_difference_map(
 ):
     _validate_environment(ccp4=False)
     
-    # make sure directories have a trailing slash!
-    # if input_dir[-1] != "/":
-    #     input_dir = input_dir + "/"
-
-    # if output_dir[-1] != "/":
-    #     output_dir = output_dir + "/"
+    output_dir_contents = output_dir.glob("*")
 
     rbr_phenix, rbr_gemmi = _rbr_selection_parser(ncs_chains)
 

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -14,7 +14,6 @@ import reciprocalspaceship as rs
 
 from matchmaps._utils import (
     _handle_special_positions,
-    # align_grids_from_model_transform,
     make_floatgrid_from_mtz,
     rigid_body_refinement_wrapper,
     _realspace_align_and_subtract,

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -23,6 +23,7 @@ from matchmaps._utils import (
     _ncs_align_and_subtract,
     _validate_environment,
     _validate_inputs,
+    _clean_up_files,
 )
 
 
@@ -42,10 +43,11 @@ def compute_ncs_difference_map(
     ncs_chains=None,
     refine_ncs_separately=False,
     eff=None,
+    keep_temp_files=None
 ):
     _validate_environment(ccp4=False)
     
-    output_dir_contents = output_dir.glob("*")
+    output_dir_contents = list(output_dir.glob("*"))
 
     rbr_phenix, rbr_gemmi = _rbr_selection_parser(ncs_chains)
 
@@ -103,7 +105,14 @@ def compute_ncs_difference_map(
         output_dir=output_dir,
         name=name,
     )
+    
+    print(f"{time.strftime('%H:%M:%S')}: Cleaning up files...")
+    print(keep_temp_files)
+    _clean_up_files(output_dir, output_dir_contents, keep_temp_files)
 
+    print(f"{time.strftime('%H:%M:%S')}: Done!")
+
+    return
 
 def parse_arguments():
     """Parse commandline arguments."""
@@ -232,7 +241,18 @@ def parse_arguments():
         default=None,
         help=("Custom .eff template for running phenix.refine. "),
     )
-
+    
+    parser.add_argument(
+        "--keep-temp-files",
+        "-k",
+        required=False,
+        default=None,
+        help=(
+            "Do not delete intermediate matchmaps files, but rather place them in the supplied directory. "
+            "This directory is created as a subdirectory of the supplied output-dir."
+        )
+    )
+    
     return parser
 
 
@@ -269,6 +289,7 @@ def main():
         eff=args.eff,
         dmin=args.dmin,
         spacing=args.spacing,
+        keep_temp_files=args.keep_temp_files,
     )
 
     return

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -172,11 +172,11 @@ def compute_realspace_difference_map(
 
     # read back in the files created by phenix
     # these have knowable names
-    mtzon = rs.read_mtz(f"{str(nickname_on)}_1.mtz")
-    mtzoff = rs.read_mtz(f"{str(nickname_off)}_1.mtz")
+    mtzon = rs.read_mtz(f"{nickname_on}_1.mtz")
+    mtzoff = rs.read_mtz(f"{nickname_off}_1.mtz")
 
-    pdbon = gemmi.read_structure(f"{str(nickname_on)}_1.pdb")
-    pdboff = gemmi.read_structure(f"{str(nickname_off)}_1.pdb")
+    pdbon = gemmi.read_structure(f"{nickname_on}_1.pdb")
+    pdboff = gemmi.read_structure(f"{nickname_off}_1.pdb")
 
     if dmin is None:
         dmin = max(

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -6,6 +6,7 @@ import glob
 import subprocess
 import time
 from functools import partial
+from pathlib import Path
 
 import gemmi
 import numpy as np
@@ -20,7 +21,8 @@ from matchmaps._utils import (
     _rbr_selection_parser,
     _renumber_waters,
     # _clean_up_files,
-    _validate_environment
+    _validate_environment,
+    _validate_inputs,
 )
 
 
@@ -36,8 +38,8 @@ def compute_realspace_difference_map(
     dmin=None,
     spacing=0.5,
     on_as_stationary=False,
-    input_dir="./",
-    output_dir="./",
+    input_dir=Path("."),
+    output_dir=Path("."),
     verbose=False,
     rbr_selections=None,
     eff=None,
@@ -47,11 +49,11 @@ def compute_realspace_difference_map(
 
     Parameters
     ----------
-    pdboff : string
+    pdboff : pathlib.Path
         Name of input .pdb file to use for phasing
-    mtzoff : string
+    mtzoff : pathlib.Path
         Name of input .mtz file containing 'off' data
-    mtzon : string
+    mtzon : pathlib.Path
         Name of input .mtz file containing 'off' data
     Foff : string
         Column in mtzoff containing structure factor amplitudes
@@ -61,7 +63,7 @@ def compute_realspace_difference_map(
         Column in mtzon containing structure factor amplitudes
     SigFon : string
         Column in mtzon containing structure factor uncertainties
-    ligands : list of strings
+    ligands : list of pathlib.Path
         Filename(s) of any .cif ligand restraint files necessary for phenix.refine
         by default None, meaning only the .pdb is required for refinement
     dmin : float, optional
@@ -71,9 +73,9 @@ def compute_realspace_difference_map(
         Approximate size of real-space voxels in Angstroms, by default 0.5 A
     on_as_stationary : bool, optional
         If True, align "off" data onto "on" data, by default False
-    input_dir : str, optional
+    input_dir : pathlib.Path, optional
         Path to directory containing input files, by default "./" (current directory)
-    output_dir : str, optional
+    output_dir : pathlib.Path, optional
         Path to directory to which output files should be written, by default "./" (current directory)
     verbose : bool, optional
         If True, print outputs of scaleit and phenix.refine, by default False
@@ -85,70 +87,61 @@ def compute_realspace_difference_map(
         If omitted, the sensible built-in .eff template is used. If you need to change something,
         I recommend copying the template from the source code and editing that.
     """
-    
+
     _validate_environment(ccp4=True)
-    
-    off_name = str(mtzoff.removesuffix(".mtz"))
-    on_name = str(mtzon.removesuffix(".mtz"))
 
-    # make sure directories have a trailing slash!
-    if input_dir[-1] != "/":
-        input_dir = input_dir + "/"
+    off_name = mtzoff.name.removesuffix(".mtz")
+    on_name = mtzon.name.removesuffix(".mtz")
 
-    if output_dir[-1] != "/":
-        output_dir = output_dir + "/"
-        
-    output_dir_contents = glob.glob(output_dir + "*")
+    output_dir_contents = output_dir.glob("*")
 
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)
     rbr_phenix, rbr_gemmi = _rbr_selection_parser(rbr_selections)
 
     ### scaleit
-    mtzon_scaled = mtzon.removesuffix(".mtz") + "_scaled" + ".mtz"
+    #mtzon_scaled = mtzon.removesuffix(".mtz") + "_scaled" + ".mtz"
+    mtzon_scaled = output_dir / (mtzon.name.removesuffix(".mtz") + "_scaled.mtz")
 
     print(
         f"{time.strftime('%H:%M:%S')}: Running scaleit to scale 'on' data to 'off' data..."
     )
 
     subprocess.run(
-        f"rs.scaleit -r {input_dir}/{mtzoff} {Foff} {SigFoff} -i {input_dir}/{mtzon} {Fon} {SigFon} -o {output_dir}/{mtzon_scaled}",
+        f"rs.scaleit -r {mtzoff} {Foff} {SigFoff} -i {mtzon} {Fon} {SigFon} -o {mtzon_scaled}",
         shell=True,
         capture_output=(not verbose),
     )
-    
+
     ## now that scaleit has run, let's swap out the spacegroup from the scaled file
-    mtzon_scaled_py = rs.read_mtz(f'{output_dir}/{mtzon_scaled}')
-    mtzon_original_py = rs.read_mtz(f'{input_dir}/{mtzon}')
-    mtzoff_original_py = rs.read_mtz(f'{input_dir}/{mtzoff}')
+    mtzon_scaled_py = rs.read_mtz(str(mtzon_scaled))
+    mtzon_original_py = rs.read_mtz(str(mtzon))
+    mtzoff_original_py = rs.read_mtz(str(mtzoff))
     
-    mtzoff_trunc = mtzoff.removesuffix(".mtz") + "_trunc.mtz"
-    mtzon_scaled_truecell = mtzon_scaled.removesuffix(".mtz") + "_truecell.mtz"
+    mtzoff_trunc = output_dir / (mtzoff.name.removesuffix(".mtz") + "_trunc.mtz")
+    mtzon_scaled_truecell = output_dir / (mtzon_scaled.name.removesuffix(".mtz") + "_truecell.mtz")
     
     mtzon_scaled_py.cell = mtzon_original_py.cell
-    
+
     mtzoff_original_py.compute_dHKL(inplace=True)
     mtzon_scaled_py.compute_dHKL(inplace=True)
-    
+
     # make resolutions match for mtzon_scaled_py and mtzon_original_py
-    resolution = max(
-        mtzoff_original_py["dHKL"].min(),
-        mtzon_scaled_py["dHKL"].min()
-    )
+    resolution = max(mtzoff_original_py["dHKL"].min(), mtzon_scaled_py["dHKL"].min())
     mtzoff_original_py = mtzoff_original_py.loc[mtzoff_original_py.dHKL >= resolution]
     mtzon_scaled_py = mtzon_scaled_py.loc[mtzon_scaled_py.dHKL >= resolution]
-    
-    mtzoff_original_py.write_mtz(f'{output_dir}/{mtzoff_trunc}')
-    mtzon_scaled_py.write_mtz(f'{output_dir}/{mtzon_scaled_truecell}')
-    
-    # reset short nicknames to the latest files 
+
+    mtzoff_original_py.write_mtz(str(mtzoff_trunc))
+    mtzon_scaled_py.write_mtz(str(mtzon_scaled_truecell))
+
+    # reset short nicknames to the latest files
     mtzon = mtzon_scaled_truecell
     mtzoff = mtzoff_trunc
     ## done with cell swapping and resolution matching
-    
-    pdboff = _handle_special_positions(pdboff, input_dir, output_dir)
 
-    pdboff = _renumber_waters(pdboff, output_dir)
+    pdboff = _handle_special_positions(pdboff, output_dir)
+
+    pdboff = _renumber_waters(pdboff)
 
     print(f"{time.strftime('%H:%M:%S')}: Running phenix.refine for the 'on' data...")
 
@@ -179,11 +172,11 @@ def compute_realspace_difference_map(
 
     # read back in the files created by phenix
     # these have knowable names
-    mtzon = rs.read_mtz(f"{output_dir}/{nickname_on}_1.mtz")
-    mtzoff = rs.read_mtz(f"{output_dir}/{nickname_off}_1.mtz")
+    mtzon = rs.read_mtz(f"{str(nickname_on)}_1.mtz")
+    mtzoff = rs.read_mtz(f"{str(nickname_off)}_1.mtz")
 
-    pdbon = gemmi.read_structure(f"{output_dir}/{nickname_on}_1.pdb")
-    pdboff = gemmi.read_structure(f"{output_dir}/{nickname_off}_1.pdb")
+    pdbon = gemmi.read_structure(f"{str(nickname_on)}_1.pdb")
+    pdboff = gemmi.read_structure(f"{str(nickname_off)}_1.pdb")
 
     if dmin is None:
         dmin = max(
@@ -381,23 +374,26 @@ def main():
     parser = parse_arguments()
     args = parser.parse_args()
 
-    if not os.path.exists(args.output_dir):
-        os.makedirs(args.output_dir)
-
-    if not os.path.exists(args.input_dir):
-        raise ValueError(f"Input directory '{args.input_dir}' does not exist")
+    (input_dir, output_dir, ligands, mtzoff, mtzon, pdboff) = _validate_inputs(
+        args.input_dir,
+        args.output_dir,
+        args.ligands,
+        args.mtzoff[0],
+        args.mtzon[0],
+        args.pdboff,
+    )
 
     compute_realspace_difference_map(
-        pdboff=args.pdboff,
-        ligands=args.ligands,
-        mtzoff=args.mtzoff[0],
-        mtzon=args.mtzon[0],
+        pdboff=pdboff,
+        ligands=ligands,
+        mtzoff=mtzoff,
+        mtzon=mtzon,
         Foff=args.mtzoff[1],
         SigFoff=args.mtzoff[2],
         Fon=args.mtzon[1],
         SigFon=args.mtzon[2],
-        input_dir=args.input_dir,
-        output_dir=args.output_dir,
+        input_dir=input_dir,
+        output_dir=output_dir,
         verbose=args.verbose,
         rbr_selections=args.rbr_selections,
         eff=args.eff,

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -14,13 +14,12 @@ import reciprocalspaceship as rs
 
 from matchmaps._utils import (
     _handle_special_positions,
-    # align_grids_from_model_transform,
     make_floatgrid_from_mtz,
     rigid_body_refinement_wrapper,
     _realspace_align_and_subtract,
     _rbr_selection_parser,
     _renumber_waters,
-    # _clean_up_files,
+    _clean_up_files,
     _validate_environment,
     _validate_inputs,
 )
@@ -43,6 +42,7 @@ def compute_realspace_difference_map(
     verbose=False,
     rbr_selections=None,
     eff=None,
+    keep_temp_files=None,
 ):
     """
     Compute a real-space difference map from mtzs.
@@ -93,7 +93,7 @@ def compute_realspace_difference_map(
     off_name = mtzoff.name.removesuffix(".mtz")
     on_name = mtzon.name.removesuffix(".mtz")
 
-    output_dir_contents = output_dir.glob("*")
+    output_dir_contents = list(output_dir.glob("*"))
 
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)
@@ -224,9 +224,9 @@ def compute_realspace_difference_map(
                 on_as_stationary=on_as_stationary,
                 selection=selection,
             )
-    # print(f"{time.strftime('%H:%M:%S')}: Cleaning up files...")
-
-    # _clean_up_files()
+    
+    print(f"{time.strftime('%H:%M:%S')}: Cleaning up files...")
+    _clean_up_files(output_dir, output_dir_contents, keep_temp_files)
 
     print(f"{time.strftime('%H:%M:%S')}: Done!")
 
@@ -366,6 +366,17 @@ def parse_arguments():
         default=None,
         help=("Custom .eff template for running phenix.refine. "),
     )
+    
+    parser.add_argument(
+        "--keep-temp-files",
+        "-k",
+        required=False,
+        default=None,
+        help=(
+            "Do not delete intermediate matchmaps files, but rather place them in the supplied directory. "
+            "This directory is created as a subdirectory of the supplied output-dir."
+        )
+    )
 
     return parser
 
@@ -400,6 +411,7 @@ def main():
         dmin=args.dmin,
         spacing=args.spacing,
         on_as_stationary=args.on_as_stationary,
+        keep_temp_files=args.keep_temp_files,
     )
 
     return

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -879,36 +879,23 @@ def _validate_inputs(
             raise ValueError(f"Input file '{f}' does not exist")
         
     return input_dir, output_dir, ligands, *files
-    
 
-# def _find_available_dirname(prefix):
-#     existing = glob.glob(f"{prefix}_[0-9]*/")
 
-#     if len(existing) == 0:
-#         new_suffix = "0"
-#     else:
-#         n = max([int(s.split("_")[-1].removesuffix("/")) for s in existing])
-#         new_suffix = f"{n+1}"
+def _clean_up_files(output_dir, old_files, keep_temp_files):
 
-#     return new_suffix
-
-# def _clean_up_files(output_dir, old_files):
-    
-#     prefix='matchmapsfiles'
-
-#     n = _find_available_dirname(prefix)
-#     cleanup_dir = f"{output_dir}/prefix_{n}"
-
-#     os.mkdir(cleanup_dir)
-
-#     candidate_files = []
-#     for suffix in ('eff', 'pdb', 'mtz', 'log', 'cif'):
-#         candidate_files.append(glob.glob(output_dir + '*' + suffix))
+    candidate_files = []
+    for suffix in ('eff', 'pdb', 'mtz', 'log', 'cif'):
+        candidate_files.extend(list(output_dir.glob('*' + suffix)))
         
-#     files_to_move = list(filter(
-#         lambda x: 
-#             x not in old_files, 
-#         candidate_files
-#         )) 
-
-#     return
+    files_to_delete = set(candidate_files) - set(old_files)
+    
+    if keep_temp_files is not None:
+        new_dir = output_dir / keep_temp_files
+        new_dir.mkdir(parents=True, exist_ok=True)
+        for f in files_to_delete:
+            f.rename(new_dir / f.name)
+    else:
+        for f in files_to_delete:
+            os.remove(f)    
+    
+    return

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -891,6 +891,7 @@ def _clean_up_files(output_dir, old_files, keep_temp_files):
     
     if keep_temp_files is not None:
         new_dir = output_dir / keep_temp_files
+        print(new_dir)
         new_dir.mkdir(parents=True, exist_ok=True)
         for f in files_to_delete:
             f.rename(new_dir / f.name)

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -825,14 +825,14 @@ def _ncs_align_and_subtract(
         rs.io.write_ccp4_map, cell=fg.unit_cell, spacegroup=fg.spacegroup
     )
 
-    write_maps(fg.array, f"{output_dir}/{name}_{ncs_chains[0]}.map")
+    write_maps(fg.array, str(output_dir / (name + "_" + ncs_chains[0] + ".map")))
     write_maps(
-        fg2.array, f"{output_dir}/{name}_{ncs_chains[1]}_onto_{ncs_chains[0]}.map"
+        fg2.array, str(output_dir / (name + "_" + ncs_chains[1] + "_onto_" + ncs_chains[0] + ".map"))
     )
 
     write_maps(
         fg2.array - fg.array,
-        f"{output_dir}/{name}_{ncs_chains[1]}_minus_{ncs_chains[0]}.map",
+       str(output_dir / (name + "_" + ncs_chains[1] + "_minus_" + ncs_chains[0] + ".map"))
     )
 
     print(f"{time.strftime('%H:%M:%S')}: Done!")
@@ -857,19 +857,21 @@ def _validate_inputs(
 
     if not input_dir.exists():
         raise ValueError(f"Input directory '{input_dir}' does not exist")
+    
+    if ligands is not None:
+        ligands = [Path(ligand) for ligand in ligands]
+        
+        ligands = [ligand if ligand.is_absolute() else input_dir/ligand
+                for ligand in ligands]
 
-    ligands = [Path(ligand) for ligand in ligands]
+        for ligand in ligands:
+            if not ligand.exists():
+                raise ValueError(f"Input ligand '{ligand}' does not exist")
+        
     files = [Path(f) for f in files]
-    
-    ligands = [ligand if ligand.is_absolute() else input_dir/ligand
-               for ligand in ligands]
-    
+  
     files = [f if f.is_absolute() else input_dir/f
              for f in files]
-    
-    for ligand in ligands:
-        if not ligand.exists():
-            raise ValueError(f"Input ligand '{ligand}' does not exist")
     
     for f in files:
         if not f.exists():


### PR DESCRIPTION
Where appropriate, all file paths are now handled as `pathlib.Path` objects, rather than just strings. In addition to just being best practice, this carries the following advantages:

 - Easier validation that the provided files actually exist
 - Files can be provided either as filenames alongside the `--input-dir` flag, or as relative paths, or as absolute paths.
 - In theory, the package should now be Windows compatible? I have not tested this. At the very least, there are no longer any forward slashes hard-coded in!
 - Easier incorporation of file cleanup. 