### PR TITLE
Normalize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ repository = "https://github.com/rs-station/matchmaps"
 matchmaps = "matchmaps._compute_realspace_diff:main"
 "matchmaps.ncs" = "matchmaps._compute_ncs_diff:main"
 "matchmaps.mr" = "matchmaps._compute_mr_diff:main"
+"matchmaps.version" = "matchmaps._version:main"
 
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.version]

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -631,10 +631,11 @@ def _realspace_align_and_subtract(
         pdb_for_mask = _extract_pdb_selection(pdb_fixed[0], selection)
 
     masker.put_mask_on_float_grid(fg_mask_only, pdb_for_mask)
-    masked_difference_array = np.logical_not(fg_mask_only.array) * difference_array
     
-    # normalize the difference array
-    
+    # mask difference array and normalize the unmasked part
+    boolean_mask = np.logical_not(fg_mask_only.array).astype(bool)
+    masked_difference_array = boolean_mask * difference_array
+    masked_difference_array[boolean_mask] = _quicknorm(masked_difference_array[boolean_mask])    
     
     # and finally, write stuff out
 


### PR DESCRIPTION
`matchmaps` and `matchmaps.mr` now normalize only the unmasked region of the difference map. `matchmaps.ncs` already had this functionality.

Note that this does NOT mean that the output difference map has a standard deviation of 1, but rather, that the non-zero/masked region of the difference map has a standard deviation of 1. The mean should be 0 either way, of course.

This PR also adds a `matchmaps.version` utility which prints out the version number; this will be nice for reproducibility in publication scripts!