### PR TITLE
patch bug in version utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ repository = "https://github.com/rs-station/matchmaps"
 matchmaps = "matchmaps._compute_realspace_diff:main"
 "matchmaps.ncs" = "matchmaps._compute_ncs_diff:main"
 "matchmaps.mr" = "matchmaps._compute_mr_diff:main"
-"matchmaps.version" = "matchmaps._version:main"
+"matchmaps.version" = "matchmaps._version_util:main"
 
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.version]

--- a/src/matchmaps/_version_util.py
+++ b/src/matchmaps/_version_util.py
@@ -1,0 +1,10 @@
+"""matchmaps.version returns package version"""
+
+from importlib.metadata import version
+
+def main():
+    print(version("matchmaps"))
+    return
+
+if __name__ == "__ main__": 
+    main()


### PR DESCRIPTION
It seems that `_version.py` is some sort of special file name and does not get imported normally. I changed the file name to `_version_util.py`, and that seems to have fixed it!

This fix will be patched into version `0.4.1`.