### PR TITLE
Support `.cif` inputs as alternatives to `.pdb`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ matchmaps/_version.py
 src/matchmaps/_version.py
 
 .DS_Store
+docs/.DS_Store
+src/.DS_Store
 .cruft.json
 
 # weird thing

--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,8 @@ src/matchmaps/_version.py
 .DS_Store
 .cruft.json
 
+# weird thing
+.notconda/*
+
 # logo in illustrator
 docs/images/logo.ai

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -22,6 +22,7 @@ from matchmaps._utils import (
     _validate_inputs,
     phaser_wrapper,
     _clean_up_files,
+    _cif_or_pdb_to_pdb,
 )
 
 
@@ -91,11 +92,13 @@ def compute_mr_difference_map(
     
     _validate_environment(ccp4=False)
 
+    output_dir_contents = list(output_dir.glob("*"))
+    
     off_name = mtzoff.name.removesuffix(".mtz")
     on_name = mtzon.name.removesuffix(".mtz")
     
-    output_dir_contents = list(output_dir.glob("*"))
-
+    pdboff = _cif_or_pdb_to_pdb(pdboff, output_dir)
+    
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)
     rbr_phenix, rbr_gemmi = _rbr_selection_parser(rbr_selections)

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -240,10 +240,11 @@ def parse_arguments():
             "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
             "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
             "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
-            "Please note that both ccp4 and phenix must be installed and active in your environment for this function to run. "
+            "The input file may be in .pdb or .cif format. "
+            "Please note that phenix must be installed and active in your environment for this function to run. "
             ""
-            "If your mtzoff and mtzon are in the same spacegroup and crystal packing, see the basic matchmaps utility "
-            "If you'd like to make an internal difference map, see matchmaps.ncs "
+            "If your mtzoff and mtzon are in the same spacegroup and crystal packing, see the basic matchmaps utility. "
+            "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
         )
     )
 
@@ -277,8 +278,8 @@ def parse_arguments():
         "-p",
         required=True,
         help=(
-            "Reference pdb corresponding to the off/apo/ground/dark state. "
-            "Used for rigid-body refinement of both input MTZs to generate phases."
+            "Reference pdb/cif corresponding to the off/apo/ground/dark state. "
+            "Used as a molecular replacement solution for mtzon and for rigid-body refinement of both input MTZs to generate phases."
             "Should match mtzoff well enough that molecular replacement is not necessary."
         ),
     )

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -134,7 +134,7 @@ def parse_arguments():
         required=True,
         help=(
             "MTZ file containing structure factor amplitudes. "
-            "Specified as [filename F SigF] or [filename F]"
+            "Specified as [filename F SigF] or [filename F]. "
             "SigF is not necessary if phases are also provided"
         ),
     )

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -121,8 +121,11 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description=(
             "Compute an 'internal' real-space difference map between NCS-related molecules. "
-            "You will need an MTZ file with structure factor amplitudes and optionally containing phases, and a PDB file."
-            "Please note that both ccp4 and phenix must be installed and active in your environment for this function to run. "
+            "You will need an MTZ file with structure factor amplitudes and optionally containing phases, and a PDB/CIF file."
+            ""
+            "Please note that phenix must be installed and active in your environment for this function to run. "
+            ""
+            "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
         )
     )
 
@@ -155,7 +158,7 @@ def parse_arguments():
         "-p",
         required=True,
         help=(
-            "Reference pdb. "
+            "Reference pdb/cif. "
             "If phases are not provided, used for rigid-body refinement of input MTZ to generate phases."
         ),
     )

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -23,6 +23,7 @@ from matchmaps._utils import (
     _validate_environment,
     _validate_inputs,
     _clean_up_files,
+    _cif_or_pdb_to_pdb,
 )
 
 
@@ -47,7 +48,9 @@ def compute_ncs_difference_map(
     _validate_environment(ccp4=False)
     
     output_dir_contents = list(output_dir.glob("*"))
-
+    
+    pdb = _cif_or_pdb_to_pdb(pdb, output_dir)
+    
     rbr_phenix, rbr_gemmi = _rbr_selection_parser(ncs_chains)
 
     if Phi is None:  # do rigid-body refinement to get phases

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -23,6 +23,7 @@ from matchmaps._utils import (
     _validate_environment,
     _validate_inputs,
     #_cif_or_mtz_to_mtz,
+    _cif_or_pdb_to_pdb,
 )
 
 
@@ -93,8 +94,11 @@ def compute_realspace_difference_map(
 
     output_dir_contents = list(output_dir.glob("*"))
 
-    off_name = mtzoff.name.removesuffix(".mtz")#.removesuffix(".cif")
-    on_name = mtzon.name.removesuffix(".mtz")#.removesuffix(".cif")
+    off_name = mtzoff.name.removesuffix(".mtz")
+    on_name = mtzon.name.removesuffix(".mtz")
+    
+    pdboff = _cif_or_pdb_to_pdb(pdboff, output_dir)
+
     # off_name = _cif_or_mtz_to_mtz(mtzoff)
     # on_name = _cif_or_mtz_to_mtz(mtzon)
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -22,7 +22,7 @@ from matchmaps._utils import (
     _clean_up_files,
     _validate_environment,
     _validate_inputs,
-    _cif_or_mtz_to_mtz,
+    #_cif_or_mtz_to_mtz,
 )
 
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -22,6 +22,7 @@ from matchmaps._utils import (
     _clean_up_files,
     _validate_environment,
     _validate_inputs,
+    _cif_or_mtz_to_mtz,
 )
 
 
@@ -87,21 +88,22 @@ def compute_realspace_difference_map(
         If omitted, the sensible built-in .eff template is used. If you need to change something,
         I recommend copying the template from the source code and editing that.
     """
-
+    
     _validate_environment(ccp4=True)
 
-    off_name = mtzoff.name.removesuffix(".mtz")
-    on_name = mtzon.name.removesuffix(".mtz")
-
     output_dir_contents = list(output_dir.glob("*"))
+
+    off_name = mtzoff.name.removesuffix(".mtz")#.removesuffix(".cif")
+    on_name = mtzon.name.removesuffix(".mtz")#.removesuffix(".cif")
+    # off_name = _cif_or_mtz_to_mtz(mtzoff)
+    # on_name = _cif_or_mtz_to_mtz(mtzon)
 
     # take in the list of rbr selections and parse them into phenix and gemmi selection formats
     # if rbr_groups = None, just returns (None, None)
     rbr_phenix, rbr_gemmi = _rbr_selection_parser(rbr_selections)
 
     ### scaleit
-    #mtzon_scaled = mtzon.removesuffix(".mtz") + "_scaled" + ".mtz"
-    mtzon_scaled = output_dir / (mtzon.name.removesuffix(".mtz") + "_scaled.mtz")
+    mtzon_scaled = output_dir / (on_name + "_scaled.mtz")
 
     print(
         f"{time.strftime('%H:%M:%S')}: Running scaleit to scale 'on' data to 'off' data..."

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -248,9 +248,10 @@ def parse_arguments():
             "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
             "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
             "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
+            "The input file may be in .pdb or .cif format. "
             "Please note that both ccp4 and phenix must be installed and active in your environment for this function to run. "
             ""
-            "If you'd like to make an internal difference map instead, see matchmaps.ncs "
+            "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
         )
     )
 
@@ -283,7 +284,7 @@ def parse_arguments():
         "-p",
         required=True,
         help=(
-            "Reference pdb corresponding to the off/apo/ground/dark state. "
+            "Reference pdb/cif corresponding to the off/apo/ground/dark state. "
             "Used for rigid-body refinement of both input MTZs to generate phases."
         ),
     )

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -325,11 +325,13 @@ def _handle_special_positions(pdboff, output_dir):
     If any non-water atoms sit on special positions, throw a (hopefully helpful) error.
 
     Regardless of whether any special positions were found, copy this file over to output_dir
+    
+    Additionally, regardless of whether the input is a .pdb or .cif file, write the output to a .pdb file for downstream use.
 
     Parameters
     ----------
-    pdboff : str
-        name of input pdb
+    pdboff : pathlib.Path
+        name of input pdb (or mmcif)
     output_dir : str
     """
     pdb = gemmi.read_structure(str(pdboff))
@@ -363,10 +365,13 @@ Alternatively, you can remove this atom from your structure altogether and try a
 """
                             )
 
-    pdboff_nospecialpositions = output_dir / (pdboff.name.removesuffix(".pdb") + "_nospecialpositions.pdb")
+    if pdboff.suffix in ('.cif', '.CIF'):
+        pdboff_nospecialpositions = output_dir / (pdboff.name.lower().removesuffix(".cif") + "_nospecialpositions.pdb")
+        pdb.make_mmcif_document().write_file(str(pdboff_nospecialpositions))
+    else:
+        pdboff_nospecialpositions = output_dir / (pdboff.name.removesuffix(".pdb") + "_nospecialpositions.pdb")
+        pdb.write_pdb(str(pdboff_nospecialpositions))
     
-    pdb.write_pdb(str(pdboff_nospecialpositions))
-
     return pdboff_nospecialpositions
 
 
@@ -880,6 +885,17 @@ def _validate_inputs(
             raise ValueError(f"Input file '{f}' does not exist")
         
     return input_dir, output_dir, ligands, *files
+
+
+# def _cif_or_mtz_to_mtz(path):
+    
+#     if path.suffix.lower() == '.mtz':
+#         reflections = rs.read_mtz(str(path))
+        
+#     elif path.suffix.lower() == '.cif':
+#         reflections = rs.read_cif(str(path))
+    
+#     return name
 
 
 def _clean_up_files(output_dir, old_files, keep_temp_files):

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -365,12 +365,12 @@ Alternatively, you can remove this atom from your structure altogether and try a
 """
                             )
 
-    if pdboff.suffix in ('.cif', '.CIF'):
-        pdboff_nospecialpositions = output_dir / (pdboff.name.lower().removesuffix(".cif") + "_nospecialpositions.pdb")
-        pdb.make_mmcif_document().write_file(str(pdboff_nospecialpositions))
-    else:
-        pdboff_nospecialpositions = output_dir / (pdboff.name.removesuffix(".pdb") + "_nospecialpositions.pdb")
-        pdb.write_pdb(str(pdboff_nospecialpositions))
+    # if pdboff.suffix in ('.cif', '.CIF'):
+    #     pdboff_nospecialpositions = output_dir / (pdboff.name.lower().removesuffix(".cif") + "_nospecialpositions.pdb")
+    #     pdb.make_mmcif_document().write_file(str(pdboff_nospecialpositions))
+    # else:
+    pdboff_nospecialpositions = output_dir / (pdboff.name.removesuffix(".pdb") + "_nospecialpositions.pdb")
+    pdb.write_pdb(str(pdboff_nospecialpositions))
     
     return pdboff_nospecialpositions
 
@@ -405,7 +405,6 @@ def _remove_waters(
     output_dir,
 ):
     pdb_dry = pdb.name.removesuffix(".pdb") + "_dry"
-    # output_pdb = input_pdb.removesuffix(".pdb") + "_dry"
 
     subprocess.run(
         f"phenix.pdbtools {pdb} remove='water' \
@@ -887,7 +886,7 @@ def _validate_inputs(
     return input_dir, output_dir, ligands, *files
 
 
-# def _cif_or_mtz_to_mtz(path):
+# def _cif_or_mtz_to_mtz(input_file, output_dir):
     
 #     if path.suffix.lower() == '.mtz':
 #         reflections = rs.read_mtz(str(path))
@@ -897,6 +896,25 @@ def _validate_inputs(
     
 #     return name
 
+def _cif_or_pdb_to_pdb(input_file, output_dir):
+    
+    if input_file.suffix.lower() == '.pdb':
+        
+        output_file = output_dir / (input_file.name)
+        
+        shutil.copy(input_file, output_file)
+        
+    elif input_file.suffix.lower() == '.cif':
+        
+        output_file = output_dir / (input_file.name.lower().removesuffix('.cif') + '.pdb')
+        
+        structure = gemmi.read_structure(str(input_file))
+        structure.write_pdb(str(output_file))
+    
+    else:
+        raise ValueError(f"Invalid file type {input_file.suffix} for starting model, must be '.pdb' or '.cif'")
+    
+    return output_file
 
 def _clean_up_files(output_dir, old_files, keep_temp_files):
 

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -524,7 +524,6 @@ def _restore_ligand_occupancy(
         if ("HETATM" in l) and (not "REMARK" in l):
             original_hetatm.append(l)
     original_occs = [h[56:60] for h in original_hetatm]
-    print(len(original_occs))
 
     with open(pdb_to_be_restored, "r") as p:
         pdb = p.readlines()


### PR DESCRIPTION
This PR allows all three `matchmaps` utilities to take accept input starting models in either `.pdb`. or `.cif` formats. The `.cif` format is increasingly common / preferred as the file type for macromolecular structures, so this is good to support going forward.

In order to preserve as much existing code as possible, this change is implemented via a `_cif_or_pdb_to_pdb()` helper function. When given a `.pdb` input file, this function simply copies that file over to the output directory. When given a `.cif` input file, this function reads the file into python (via `gemmi`) and then writes out an analogous `.pdb`-formatted file into the output directory.

Structure factor `.cif`s are not yet supported.