### PR TITLE
Write out `.sh` file for reproducing command

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,6 +107,11 @@ matchmaps --mtzoff apo_data.mtz Fobs SIGFobs \
     --output-dir ../data/myproject \
 ```
 
+### Running `matchmaps` from a script
+After your `matchmaps` run completes successfully, it will write out a file (called `run_matchmaps.sh` unless you specify a different name to the `--script` flag) which can be run to reproduce exactly the same command. Note that, to ensure the compatibility of input/output paths, this script is written to your ***current working directory***.
+
+If you'd then like to run `matchmaps` again with slightly different parameters, you can use this script as a starting point. No need to remember exactly which parameters you used the first time!
+
 ## Other useful options
 
  - `--on-as-stationary`: The `matchmaps` algorithm always involves an alignment in real-space of the "on" and "off" maps. By default, the "off" map is stationary, and the "on" map is moved. This is typically desired, such that everything lines up with your "off" structural model. However, say that your structures are "apo" and "bound", and you would like to line up your maps with a "bound" structure (which you never have to supply to `matchmaps`!). In this case, you could use the `--on-as-stationary` flag.

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 import subprocess
 import time
 from functools import partial
@@ -25,6 +26,7 @@ from matchmaps._utils import (
     _clean_up_files,
     _cif_or_pdb_to_pdb,
     _cif_or_mtz_to_mtz,
+    _write_script,
 )
 
 
@@ -415,6 +417,16 @@ def parse_arguments():
         )
     )
 
+    parser.add_argument(
+        "--script",
+        required=False,
+        default='run_matchmaps',
+        help=(
+            "If included, write out a file {script}.sh which can be run to repeat this command. "
+            "Note that this file is written out in the current working directory, NOT the input or output directories"
+        )
+    )
+
     return parser
 
 
@@ -457,6 +469,13 @@ def main():
         keep_temp_files=args.keep_temp_files,
         no_bss = args.no_bss
     )
+    
+    if args.script:
+        _write_script(
+            utility = 'matchmaps.mr', 
+            arguments = sys.argv[1:],
+            script_name = args.script,
+            )
 
     return
 

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -422,7 +422,8 @@ def parse_arguments():
         required=False,
         default='run_matchmaps',
         help=(
-            "If included, write out a file {script}.sh which can be run to repeat this command. "
+            "Name for a file {script}.sh which can be run to repeat this command. "
+            "By default, this file is called `run_matchmaps.sh`. "
             "Note that this file is written out in the current working directory, NOT the input or output directories"
         )
     )

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -322,7 +322,8 @@ def parse_arguments():
         required=False,
         default='run_matchmaps',
         help=(
-            "If included, write out a file {script}.sh which can be run to repeat this command. "
+            "Name for a file {script}.sh which can be run to repeat this command. "
+            "By default, this file is called `run_matchmaps.sh`. "
             "Note that this file is written out in the current working directory, NOT the input or output directories"
         )
     )

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 import subprocess
 import time
 from functools import partial
@@ -25,6 +26,7 @@ from matchmaps._utils import (
     _clean_up_files,
     _cif_or_pdb_to_pdb,
     _cif_or_mtz_to_mtz,
+    _write_script,
 )
 
 
@@ -315,6 +317,16 @@ def parse_arguments():
         )
     )
     
+    parser.add_argument(
+        "--script",
+        required=False,
+        default='run_matchmaps',
+        help=(
+            "If included, write out a file {script}.sh which can be run to repeat this command. "
+            "Note that this file is written out in the current working directory, NOT the input or output directories"
+        )
+    )
+    
     return parser
 
 
@@ -354,6 +366,13 @@ def main():
         keep_temp_files=args.keep_temp_files,
         no_bss=args.no_bss,
     )
+    
+    if args.script:
+        _write_script(
+            utility = 'matchmaps.ncs', 
+            arguments = sys.argv[1:],
+            script_name = args.script,
+            )
 
     return
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 import glob
 import subprocess
 import time
@@ -425,7 +426,6 @@ def main():
     parser = parse_arguments()
     args = parser.parse_args()
     
-    embed()
 
     (input_dir, output_dir, ligands, mtzoff, mtzon, pdboff) = _validate_inputs(
         args.input_dir,
@@ -435,7 +435,7 @@ def main():
         args.mtzon[0],
         args.pdboff,
     )
-
+    
     compute_realspace_difference_map(
         pdboff=pdboff,
         ligands=ligands,

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -12,6 +12,8 @@ import gemmi
 import numpy as np
 import reciprocalspaceship as rs
 
+from IPython import embed
+
 from matchmaps._utils import (
     _handle_special_positions,
     make_floatgrid_from_mtz,
@@ -422,6 +424,8 @@ def parse_arguments():
 def main():
     parser = parse_arguments()
     args = parser.parse_args()
+    
+    embed()
 
     (input_dir, output_dir, ligands, mtzoff, mtzon, pdboff) = _validate_inputs(
         args.input_dir,

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -27,6 +27,7 @@ from matchmaps._utils import (
     _validate_inputs,
     _cif_or_mtz_to_mtz,
     _cif_or_pdb_to_pdb,
+    _write_script,
 )
 
 
@@ -418,6 +419,16 @@ def parse_arguments():
             "This directory is created as a subdirectory of the supplied output-dir."
         )
     )
+    
+    parser.add_argument(
+        "--script",
+        required=False,
+        default='run_matchmaps',
+        help=(
+            "If included, write out a file {script}.sh which can be run to repeat this command. "
+            "Note that this file is written out in the current working directory, NOT the input or output directories"
+        )
+    )
 
     return parser
 
@@ -425,7 +436,6 @@ def parse_arguments():
 def main():
     parser = parse_arguments()
     args = parser.parse_args()
-    
 
     (input_dir, output_dir, ligands, mtzoff, mtzon, pdboff) = _validate_inputs(
         args.input_dir,
@@ -456,6 +466,13 @@ def main():
         keep_temp_files=args.keep_temp_files,
         no_bss = args.no_bss,
     )
+    
+    if args.script:
+        _write_script(
+            utility = 'matchmaps', 
+            arguments = sys.argv[1:],
+            script_name = args.script,
+            )
 
     return
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -425,7 +425,8 @@ def parse_arguments():
         required=False,
         default='run_matchmaps',
         help=(
-            "If included, write out a file {script}.sh which can be run to repeat this command. "
+            "Name for a file {script}.sh which can be run to repeat this command. "
+            "By default, this file is called `run_matchmaps.sh`. "
             "Note that this file is written out in the current working directory, NOT the input or output directories"
         )
     )

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -1002,7 +1002,7 @@ def _write_script(utility, arguments, script_name):
 
 {utility} {' '.join(arguments)}
 
-    """
+"""
     
     with open(script_name + '.sh', "w") as file:
         file.write(contents)

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -989,3 +989,22 @@ def _clean_up_files(output_dir, old_files, keep_temp_files):
             os.remove(f)    
     
     return
+
+def _write_script(utility, arguments, script_name):
+    
+    from matchmaps import __version__ as version
+    
+    contents = f"""#!/bin/bash
+
+# This file was produced by matchmaps version {version} on {time.strftime('%c')}
+# The command below was originally run in the following directory:
+# {os.getcwd()}
+
+{utility} {' '.join(arguments)}
+
+    """
+    
+    with open(script_name + '.sh', "w") as file:
+        file.write(contents)
+    
+    return


### PR DESCRIPTION
All three MatchMaps utilities now write out a shell script which can be used to re-run the utility with the same parameters.

- At present, this feature cannot be turned off
- By default, the file is called `run_matchmaps.sh` and will overwrite any other file with the same name. A different filename can be provided using the `--script` flag.
- Unlike all other `matchmaps` functionality, the shell script is written out in the ***current working directory***. This is done to ensure that the supplied input/output paths remain correct. Personally, I recommend the following file architecture:
```
.
├── input_files
│   ├── file.pdb
│   ├── file1.mtz
│   └── file2.mtz
├── mmrun1
│   └── manyfiles
├── mmrun2
│   └── manyfile
├── mmrun3
│   └── manyfiles
├── run_matchmaps_run1.sh
├── run_matchmaps_run2.sh
└── run_matchmaps_run3.sh
```
 but of course there are many good options.
