### PR TITLE
Phenix outputs include FoFc map coefficients

### DIFF
--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -244,7 +244,6 @@ refinement {
   }
 }
     """
-        print('including FoFc map')
     else:
         with open(input_dir + eff) as file:
             eff_contents = file.read()

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -224,6 +224,11 @@ refinement {
       mtz_label_amplitudes = "2FOFCWT"
       mtz_label_phases = "PH2FOFCWT"
     }
+    map_coefficients {
+      map_type = "mFo-DFc"
+      mtz_label_amplitudes = "FOFCWT"
+      mtz_label_phases = "PHFOFCWT"
+    }
   }
   refine {
     strategy = *rigid_body
@@ -239,7 +244,7 @@ refinement {
   }
 }
     """
-        # print('turned off BSS')
+        print('including FoFc map')
     else:
         with open(input_dir + eff) as file:
             eff_contents = file.read()


### PR DESCRIPTION
Originally, in the interest of minimalism, the phenix.refine outputs created by matchmaps did not include FoFc map coefficients. However, for the manuscript (and perhaps in real life too) it is of interest to compare the matchmaps difference map with with FoFc refinement map of the "on" data. The easiest way to perform this comparison is just do include the FoFc maps in the phenix outputs from the beginning, so that's what I'm doing here.