### PR TITLE
Implement proper map normalization

### DIFF
--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -628,8 +628,8 @@ def _realspace_align_and_subtract(
     # embed()
     loose_mask = np.invert(fg_on.array == 0)
     
-    fg_on[loose_mask] = _quicknorm(fg_on[loose_mask])
-    fg_off[loose_mask] = _quicknorm(fg_off[loose_mask])
+    fg_on.array[loose_mask] = _quicknorm(fg_on.array[loose_mask])
+    fg_off.array[loose_mask] = _quicknorm(fg_off.array[loose_mask])
     
     # do this again, because transformation + carving can mess up scales:
     # fg_on.normalize()

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -14,6 +14,8 @@ import re
 from functools import partial
 from pathlib import Path
 
+from IPython import embed
+
 import gemmi
 import numpy as np
 import reciprocalspaceship as rs
@@ -613,13 +615,17 @@ def _realspace_align_and_subtract(
     else:
         fg_fixed = fg_off.clone()
         pdb_fixed = pdboff.clone()
-
+    
+    # embed()    
+    
     fg_off = align_grids_from_model_transform(
         fg_fixed, fg_off, pdb_fixed, pdboff, selection, radius=radius
     )
     fg_on = align_grids_from_model_transform(
         fg_fixed, fg_on, pdb_fixed, pdbon, selection, radius=radius
     )
+    
+    # embed()
 
     # do this again, because transformation + carving can mess up scales:
     fg_on.normalize()
@@ -652,7 +658,7 @@ def _realspace_align_and_subtract(
 
     # coot refuses to render periodic boundaries for P1 maps with alpha=beta=gamma=90, sooooo
     fg_fixed.unit_cell = _unit_cell_hack(fg_fixed.unit_cell)
-
+    
     # use partial function to guarantee I'm always using the same and correct cell
     write_maps = partial(
         rs.io.write_ccp4_map, cell=fg_fixed.unit_cell, spacegroup=fg_fixed.spacegroup
@@ -758,7 +764,9 @@ def align_grids_from_model_transform(grid1, grid2, structure1, structure2, selec
     grid2_out = (
         grid1.clone()
     )  # this makes sure that grid2_out has a voxel frame matching grid1
-
+    
+    grid2_out.fill(0)
+    
     gemmi.interpolate_grid_of_aligned_model2(
         dest=grid2_out,
         src=grid2,

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -14,8 +14,6 @@ import re
 from functools import partial
 from pathlib import Path
 
-from IPython import embed
-
 import gemmi
 import numpy as np
 import reciprocalspaceship as rs
@@ -617,7 +615,7 @@ def _realspace_align_and_subtract(
     else:
         fg_fixed = fg_off.clone()
         pdb_fixed = pdboff.clone()
-    
+        
     # Use models to align grids
     # align_grids_from_model_transform is a light wrapper around gemmi.interpolate_grid_of_aligned_model2
     fg_off = align_grids_from_model_transform(
@@ -630,7 +628,7 @@ def _realspace_align_and_subtract(
     # These grids contain mostly zeros (as governed by the radius supplied above)
     # Store the locations of these zeros as a boolean array so we can ignore them
     loose_mask = np.invert(fg_on.array == 0)
-    
+        
     # Normalize the non-zero values in each grid
     fg_on.array[loose_mask] = _quicknorm(fg_on.array[loose_mask])
     fg_off.array[loose_mask] = _quicknorm(fg_off.array[loose_mask])


### PR DESCRIPTION
The map normalization that was used prior to this PR was very hacky, inconsistent across datasets, and led to confusion when using coot's vs. PyMOL's contour levels. Key improvements:

 - The mostly-full-of-zeros maps created by matchmaps are *never* subjected to gemmi's "normalize" feature, which operates over the entire unit cell. Doing so led to the zeros being replaced with some constant, small, non-zero value, and messed up everything downstream. Rather, normalization (enforcing mean=0, std=1) is only ever performed on non-zero voxels.
 - The final "unmasked" output map has matching values for "sigma" and "electrons / cubic Angstrom" by virtue of its creation. This (in combination with turning off the "normalize maps" feature in PyMOL) solves the issue of inconsistent contour levels between coot and PyMOL. The sigma and e/A^3 values differ slightly in the "masked" output, which is unavoidable, but the raw e/A^3 values match between the masked and unmasked versions.