### PR TITLE
Fix bug: unmasked_radius was parsed but ignored

### DIFF
--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -466,6 +466,7 @@ def main():
         eff=args.eff,
         dmin=args.dmin,
         spacing=args.spacing,
+        radius=args.unmasked_radius,
         on_as_stationary=args.on_as_stationary,
         keep_temp_files=args.keep_temp_files,
         no_bss = args.no_bss

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -463,6 +463,7 @@ def main():
         eff=args.eff,
         dmin=args.dmin,
         spacing=args.spacing,
+        radius=args.unmasked_radius,
         on_as_stationary=args.on_as_stationary,
         keep_temp_files=args.keep_temp_files,
         no_bss = args.no_bss,


### PR DESCRIPTION
When the `--unmasked-radius` flag was added, I never actually added that parameter to the `compute_realspace_difference_map` method inside `main`, e.g., the parameter was just being ignored. Ditto for `matchmaps.mr`. This patch fixes this bug.