### PR TITLE
Weights

### DIFF
--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -379,6 +379,18 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "--alpha",
+        required=False,
+        type=float,
+        default=0,
+        help=(
+            "Alpha to use for error weighting of F-obs prior to Fourier Transform. "
+            "Weights are computed as: 1 / ((1+(alpha*(SigF^2)) / <SigF>^2). "
+            "Default value is alpha=0, e.g., no weighting is performed. "
+        )
+    )
+
+    parser.add_argument(
         "--verbose",
         "-v",
         required=False,
@@ -467,6 +479,7 @@ def main():
         dmin=args.dmin,
         spacing=args.spacing,
         radius=args.unmasked_radius,
+        alpha=args.alpha,
         on_as_stationary=args.on_as_stationary,
         keep_temp_files=args.keep_temp_files,
         no_bss = args.no_bss

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -49,6 +49,7 @@ def compute_mr_difference_map(
     eff : str = None,
     keep_temp_files: str = None,
     radius : float = 5,
+    alpha : float = 0,
     no_bss = False,
 ):
     """
@@ -98,6 +99,8 @@ def compute_mr_difference_map(
         If not None, the name of a subdirectory of the output_dir into which intermediate matchmaps files are moved upon program completion.
     radius : float, optional
         Maximum distance away from protein model to include voxels. Only applies to the "unmasked" difference map output.
+    alpha : float, optional
+        Alpha to use in error weighting of F-obs prior to Fourier Transform. Defaults to 0, e.g. no weighting.
      no_bss : bool, optional
         If True, skip bulk solvent scaling feature of phenix.refine
     """
@@ -197,10 +200,10 @@ def compute_mr_difference_map(
     # TO-DO: Figure out why phenix outputs are sometimes still split into (+) and (-) columns, even when I specify that anomalous=False
     # As a workaround, even anomalous files have a single 'F-obs-filtered' column, so I can always just use that.
     fg_off = make_floatgrid_from_mtz(
-        mtzoff, spacing, F="F-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin
+        mtzoff, spacing, F="F-obs-filtered", SigF="SIGF-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin, alpha=alpha,
     )
     fg_on = make_floatgrid_from_mtz(
-        mtzon, spacing, F="F-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin
+        mtzon, spacing, F="F-obs-filtered", SigF="SIGF-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin, alpha=alpha,
     )
 
     if rbr_gemmi is None:

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -480,6 +480,7 @@ def main():
         dmin=args.dmin,
         spacing=args.spacing,
         radius=args.unmasked_radius,
+        alpha=args.alpha,
         on_as_stationary=args.on_as_stationary,
         keep_temp_files=args.keep_temp_files,
         no_bss = args.no_bss,

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -50,6 +50,7 @@ def compute_realspace_difference_map(
     eff : str = None,
     keep_temp_files : str = None,
     radius : float = 5,
+    alpha : float = 0,
     no_bss = False
 ):
     """
@@ -98,10 +99,12 @@ def compute_realspace_difference_map(
         If not None, the name of a subdirectory of the output_dir into which intermediate matchmaps files are moved upon program completion.
     radius : float, optional
         Maximum distance away from protein model to include voxels. Only applies to the "unmasked" difference map output.
+    alpha : float, optional
+        Alpha to use in error weighting of F-obs prior to Fourier Transform. Defaults to 0, e.g. no weighting.
     no_bss : bool, optional
         If True, skip bulk solvent scaling feature of phenix.refine
     """
-    
+
     _validate_environment(ccp4=True)
 
     output_dir_contents = list(output_dir.glob("*"))
@@ -206,11 +209,12 @@ def compute_realspace_difference_map(
     # TO-DO: Figure out why phenix outputs are sometimes still split into (+) and (-) columns, even when I specify that anomalous=False
     # As a workaround, even anomalous files have a single 'F-obs-filtered' column, so I can always just use that.
     fg_off = make_floatgrid_from_mtz(
-        mtzoff, spacing, F="F-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin
+        mtzoff, spacing, F="F-obs-filtered", SigF="SIGF-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin, alpha=alpha,
     )
     fg_on = make_floatgrid_from_mtz(
-        mtzon, spacing, F="F-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin
+        mtzon, spacing, F="F-obs-filtered", SigF="SIGF-obs-filtered", Phi="PH2FOFCWT", spacegroup="P1", dmin=dmin, alpha=alpha,
     )
+    
 
     if rbr_gemmi is None:
         _realspace_align_and_subtract(
@@ -368,6 +372,18 @@ def parse_arguments():
             "Highest-resolution (in Angstroms) reflections to include in Fourier transform for FloatGrid creation. "
             "By default, cutoff is the resolution limit of the lower-resolution input MTZ. "
         ),
+    )
+    
+    parser.add_argument(
+        "--alpha",
+        required=False,
+        type=float,
+        default=0,
+        help=(
+            "Alpha to use for error weighting of F-obs prior to Fourier Transform. "
+            "Weights are computed as: 1 / ((1+(alpha*(SigF^2)) / <SigF>^2). "
+            "Default value is alpha=0, e.g., no weighting is performed. "
+        )
     )
 
     parser.add_argument(

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -108,7 +108,7 @@ def _subparser(selection):
 
 
 def make_floatgrid_from_mtz(
-    mtz, spacing, F, SigF, Phi, spacegroup="P1", dmin=None, alpha=0.2
+    mtz, spacing, F, SigF, Phi, spacegroup="P1", dmin=None, alpha=0
 ):
     """
     Make a gemmi.FloatGrid from an rs.DataSet.


### PR DESCRIPTION
Support error-weighting of F-obs.

Weights are applied to structure factor amplitudes (Fobs) after refinement and prior to the Fourier transform. Weights are computed as:

w=1/(1+alpha*SigF^2/<SigF^2>)

The default is alpha=0, e.g. no weighting. This ensures reverse compatibility. To add weights, supply a different value for `--alpha`.

Currently the `--alpha` flag is only supported in `matchmaps` and `matchmaps.mr`. It may be added to `matchmaps.ncs` in the future.