### PR TITLE
Suppress error where scaleit fails on non-isomorphous inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,13 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
+
 dependencies = [
     "numpy",
     "tqdm",
     "reciprocalspaceship>=1.0.1",
-    "rs-booster>=0.0.1",
+    # "rs-booster>=0.0.1",
+    "rs-booster@git+https://github.com/rs-station/rs-booster.git@main",
     "gemmi"
 ]
 
@@ -70,3 +72,7 @@ matchmaps = "matchmaps._compute_realspace_diff:main"
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.version]
 source = "vcs"
+
+# this can be deleted once a new rs-booster version has been released
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -126,7 +126,7 @@ def compute_realspace_difference_map(
     )
 
     subprocess.run(
-        f"rs.scaleit -r {mtzoff} {Foff} {SigFoff} -i {mtzon} {Fon} {SigFon} -o {mtzon_scaled}",
+        f"rs.scaleit -r {mtzoff} {Foff} {SigFoff} -i {mtzon} {Fon} {SigFon} -o {mtzon_scaled} --ignore-isomorphism",
         shell=True,
         capture_output=(not verbose),
     )


### PR DESCRIPTION
This PR fixes the error raised in #43 wherein inputs which `rs.concat` flags as non-isomorphous will throw an error. Now, poorly isomorphous inputs can be used without issue.

Please note that this PR relies on the [recent update to `rs-booster`](https://github.com/rs-station/rs-booster/pull/47) which adds an `--ignore-isomorphism` option to `rs.scaleit`. Accordingly, I have tied the `rs-booster` dependency to the github development version, rather than the latest PyPI release. This also required setting the `allow-direct-references = true` option in pyproject.toml. When the rs-booster change makes it to PyPI, I will update this package accordingly.

While a fresh installation should pull the correct `rs-booster` version, I cannot guarantee that a simple `pip install --upgrade matchmaps` in an existing environment will do so. It may be necessary to explicitly call `pip install git+https://github.com/rs-station/rs-booster.git` in your environment.

To check if you have the correct version, just type `rs.scaleit -h`; if the help message includes the `--ignore-isomorphism` flag, you're good to go; if not, you need to update!