### PR TITLE
Make explicit that phenix 1.21 is not currently supported

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,6 +28,10 @@ Though `matchmaps` is a python package, it relies on two pieces of external soft
  - [ccp4](https://www.ccp4.ac.uk/download/#os=mac)
  - [phenix](https://phenix-online.org/documentation/install-setup-run.html)
 
+```{eval-rst}
+.. note::
+    Please note that phenix 1.21 is **not** supported at this time. I hope to update `matchmaps` to support this in the near future. In the meantime, make sure you're using phenix 1.20 or earlier, and everything should work fine. 
+```
 When actually using `matchmaps` in the command-line, you'll need to have both ccp4 and phenix active. Doing that will look something like:
 ```bash
 source /path/to/phenix/phenix_env.sh

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -30,6 +30,17 @@ def _validate_environment(ccp4):
             "\n"
             "For more information, see https://rs-station.github.io/matchmaps/quickstart.html#additional-dependencies"
         )
+    else:
+        version_printout = subprocess.run(
+            "phenix.version | grep Version", shell=True, capture_output=True
+        )
+        
+        version_string = str(version_printout.stdout)
+        
+        if version_string.find('21') > 0:
+            raise NotImplementedError("It seems that you are using phenix 1.21, which is not yet supported by matchmaps"
+                                      "\n"
+                                      "Please use phenix 1.20 or earlier.")
 
     if ccp4:
         if shutil.which("scaleit") is None:


### PR DESCRIPTION
This PR adds code to the `_validate_environment` method which raises a `NotImplementedError` if phenix 1.21 is detected in the environment.

The quickstart page also explains that phenix 1.21 is not supported.