### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ src/.DS_Store
 # logo in illustrator
 docs/images/logo.ai
 docs/images/logo2.ai
+
+# PyCharm files
+.idea/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "matchmaps"
 # versioning through releases
 description = "Make unbiased difference maps even for non-isomorphous inputs"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD 3-Clause License" }
 authors = [
     { email = "debrookner@gmail.com", name = "Dennis Brookner" },
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
As discussed in #51 , the type hinting used in this package is not compatible with python 3.8 and earlier. As such, I am dropping support for python 3.8 a little early (end of life is coming in October anyway).