### PR TITLE
Include `force_anomalous_to_be_equal_to = false` with phenix 1.21

### DIFF
--- a/src/matchmaps/_phenix_utils.py
+++ b/src/matchmaps/_phenix_utils.py
@@ -82,6 +82,7 @@ data_manager {
         r_free_flags {
             generate = True
         }
+        force_anomalous_flag_to_be_equal_to = False
     }
   }
 }


### PR DESCRIPTION
This PR patches a bug in which matchmaps fails when both:
 - using phenix 1.21
 - using input MTZs which result from phenix, or otherwise include anomalous information

This bug is fixed by including the `force_anomalous_to_be_equal_to = false` parameter in the template EFFs for phenix 1.21. It was already present in the equivalent template for phenix 1.20. I had previously been led to believe that this parameter was not supported in phenix 1.21, but I was mistaken.