### PR TITLE
Add a `matchmaps.diagnose` plotting utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ matchmaps = "matchmaps._compute_realspace_diff:main"
 "matchmaps.ncs" = "matchmaps._compute_ncs_diff:main"
 "matchmaps.mr" = "matchmaps._compute_mr_diff:main"
 "matchmaps.version" = "matchmaps._version_util:main"
+"matchmaps.diagnose" = "matchmaps._diagnostic_plots:main"
 
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.version]

--- a/src/matchmaps/_args.py
+++ b/src/matchmaps/_args.py
@@ -335,7 +335,10 @@ diagnose_args = (
         ("--filename",),
         {
             "required": False,
-            "help": "Base filename for the plot; should have a file extension compatible with plt.savefig",
+            "help": ("Filename for the plot to save; if it has an extension, it should be compatible with plt.savefig"
+                     "If omitted, plot will be opened interactively but no file will be saved."
+                     "File will be saved in the --output-dir directory (current directory by default)"
+                     ),
         },
     ),
     (
@@ -344,6 +347,15 @@ diagnose_args = (
             "required": False,
             "default": "Produced by matchmaps.diagnose",
             "help": "Title for the plot",
+        },
+    ),
+    (
+        ("--bins", "-b"),
+        {
+            "required": False,
+            "default": 15,
+            "help": "Numbers of resolution bins to compute correlation",
+            "type": int,
         },
     ),
 )

--- a/src/matchmaps/_args.py
+++ b/src/matchmaps/_args.py
@@ -3,242 +3,347 @@ Dictionaries for arguments parsed by one or more matchmaps utilities
 """
 
 matchmaps_description = (
-            "Compute a real-space difference map. "
-            "You will need two MTZ files, which will be referred to throughout as 'on' and 'off', "
-            "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
-            "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
-            "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
-            "The input file may be in .pdb or .cif format. "
-            "Please note that both ccp4 and phenix must be installed and active in your environment for this function to run. "
-            ""
-            "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
-        )
+    "Compute a real-space difference map. "
+    "You will need two MTZ files, which will be referred to throughout as 'on' and 'off', "
+    "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
+    "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
+    "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
+    "The input file may be in .pdb or .cif format. "
+    "Please note that both ccp4 and phenix must be installed and active in your environment for this function to run. "
+    ""
+    "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
+)
 
 matchmaps_mr_description = (
-            "Compute a real-space difference map between inputs in different space groups / crystal packings. "
-            "You will need two MTZ files, which will be referred to throughout as 'on' and 'off', "
-            "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
-            "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
-            "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
-            "The input file may be in .pdb or .cif format. "
-            "Please note that phenix must be installed and active in your environment for this function to run. "
-            ""
-            "If your mtzoff and mtzon are in the same spacegroup and crystal packing, see the basic matchmaps utility. "
-            "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
-        )
+    "Compute a real-space difference map between inputs in different space groups / crystal packings. "
+    "You will need two MTZ files, which will be referred to throughout as 'on' and 'off', "
+    "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
+    "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
+    "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
+    "The input file may be in .pdb or .cif format. "
+    "Please note that phenix must be installed and active in your environment for this function to run. "
+    ""
+    "If your mtzoff and mtzon are in the same spacegroup and crystal packing, see the basic matchmaps utility. "
+    "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
+)
 
 matchmaps_ncs_description = (
-            "Compute an 'internal' real-space difference map between NCS-related molecules. "
-            "You will need an MTZ file with structure factor amplitudes and optionally containing phases, and a PDB/CIF file."
-            ""
-            "Please note that phenix must be installed and active in your environment for this function to run. "
-            ""
-            "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
-        )
+    "Compute an 'internal' real-space difference map between NCS-related molecules. "
+    "You will need an MTZ file with structure factor amplitudes and optionally containing phases, and a PDB/CIF file."
+    ""
+    "Please note that phenix must be installed and active in your environment for this function to run. "
+    ""
+    "More information can be found online at https://rs-station.github.io/matchmaps/index.html"
+)
+
+matchmaps_diagnose_description = (
+    "Plot the isomorphism of two datasets by resolution bin."
+    "The plot is analogous to Figure 1a from the matchmaps paper (doi.org/10.1107/S1600576724003510)"
+    ""
+    "By default, the plot will open in a separate window, but you can save it with the --filename flag"
+)
 
 base_and_mr_args = (
-    (("--mtzoff", "-f"), {
-        "nargs": 3,
-        "metavar": ("mtzfileoff", "Foff", "SigFoff"),
-        "required": True,
-        "help": (
-            "MTZ or sfCIF containing off/apo/ground/dark state data. "
-            "Specified as [filename F SigF]"
-        ),
-    }),
-
-    (("--mtzon", "-n"), {
-        "nargs": 3,
-        "metavar": ("mtzfileon", "Fon", "SigFon"),
-        "required": True,
-        "help": (
-            "MTZ or sfCIF containing on/bound/excited/bright state data. "
-            "Specified as [filename F SigF]"
-        ),
-    }),
-
-    (("--pdboff", "-p"), {
-        "required": True,
-        "help": (
-            "Reference PDB or mmCIF corresponding to the off/apo/ground/dark state. "
-            "Used for rigid-body refinement of both input MTZs to generate phases."
-        ),
-    }),
-    (("--on-as-stationary",), {
-        "required": False,
-        "action": "store_true",
-        "default": False,
-        "help": (
-            "Include this flag to align 'off' data onto 'on' data. By default, 'off' data is stationary and 'on' data is moved."
-        ),
-    }),
-
-    (("--alpha",), {
-        "required": False,
-        "type": float,
-        "default": 0,
-        "help": (
-            "Alpha to use for error weighting of F-obs prior to Fourier Transform. "
-            "Weights are computed as: 1 / ((1+(alpha*(SigF^2)) / <SigF>^2). "
-            "Default value is alpha=0, e.g., no weighting is performed. "
-        )
-    }),
-
-    (("--unmasked-radius",), {
-        "required": False,
-        "type": float,
-        "default": 5,
-        "help": (
-            "Maximum distance (in Anstroms) away from protein model to include voxels. Only applies to the 'unmasked' difference map output. "
-            "Defaults to 5. "
-            "Note that the regular difference map (e.g. the 'masked' version) is not affected by this parameter and maintains a solvent mask radius of 2 Angstroms."
-        ),
-    }),
-
-    (("--rbr-selections", "-r"), {
-        "required": False,
-        "default": None,
-        "nargs": "*",
-        "help": (
-            "Specification of multiple rigid-body groups for refinement. By default, everything is refined as one rigid-body group. "
-        ),
-    }),
+    (
+        ("--mtzoff", "-f"),
+        {
+            "nargs": 3,
+            "metavar": ("mtzfileoff", "Foff", "SigFoff"),
+            "required": True,
+            "help": (
+                "MTZ or sfCIF containing off/apo/ground/dark state data. "
+                "Specified as [filename F SigF]"
+            ),
+        },
+    ),
+    (
+        ("--mtzon", "-n"),
+        {
+            "nargs": 3,
+            "metavar": ("mtzfileon", "Fon", "SigFon"),
+            "required": True,
+            "help": (
+                "MTZ or sfCIF containing on/bound/excited/bright state data. "
+                "Specified as [filename F SigF]"
+            ),
+        },
+    ),
+    (
+        ("--pdboff", "-p"),
+        {
+            "required": True,
+            "help": (
+                "Reference PDB or mmCIF corresponding to the off/apo/ground/dark state. "
+                "Used for rigid-body refinement of both input MTZs to generate phases."
+            ),
+        },
+    ),
+    (
+        ("--on-as-stationary",),
+        {
+            "required": False,
+            "action": "store_true",
+            "default": False,
+            "help": (
+                "Include this flag to align 'off' data onto 'on' data. By default, 'off' data is stationary and 'on' data is moved."
+            ),
+        },
+    ),
+    (
+        ("--alpha",),
+        {
+            "required": False,
+            "type": float,
+            "default": 0,
+            "help": (
+                "Alpha to use for error weighting of F-obs prior to Fourier Transform. "
+                "Weights are computed as: 1 / ((1+(alpha*(SigF^2)) / <SigF>^2). "
+                "Default value is alpha=0, e.g., no weighting is performed. "
+            ),
+        },
+    ),
+    (
+        ("--unmasked-radius",),
+        {
+            "required": False,
+            "type": float,
+            "default": 5,
+            "help": (
+                "Maximum distance (in Anstroms) away from protein model to include voxels. Only applies to the 'unmasked' difference map output. "
+                "Defaults to 5. "
+                "Note that the regular difference map (e.g. the 'masked' version) is not affected by this parameter and maintains a solvent mask radius of 2 Angstroms."
+            ),
+        },
+    ),
+    (
+        ("--rbr-selections", "-r"),
+        {
+            "required": False,
+            "default": None,
+            "nargs": "*",
+            "help": (
+                "Specification of multiple rigid-body groups for refinement. By default, everything is refined as one rigid-body group. "
+            ),
+        },
+    ),
 )
 
 ncs_args = (
-    (("--mtz", "-m"), {
-        "nargs": "*",
-        "required": True,
-        "help": (
-            "MTZ or sfCIF file containing structure factor amplitudes. "
-            "Specified as [filename F SigF] or [filename F]. "
-            "SigF is not necessary if phases are also provided"
-        ),
-    }),
-
-    (("--phases",), {
-        "required": False,
-        "default": None,
-        "help": (
-            "Optional. Column in MTZ/sfCIF file containing phases. "
-            "If phases are not provided, phases will be computed via rigid-body refinement of "
-            "the provided model and structure factor amplitudes."
-        ),
-    }),
-
-    (("--pdb", "-p"), {
-        "required": True,
-        "help": (
-            "Reference PDB or mmCIF. "
-            "If phases are not provided, used for rigid-body refinement of input MTZ/sfCIF to generate phases."
-        ),
-    }),
-
-    (("--ncs-chains", "-n"), {
-        "required": True,
-        "metavar": ("fixed_chain", "moving_chain"),
-        "default": None,
-        "nargs": 2,
-        "help": (
-            "NCS chains to overlay and subtract, specified as [fixed_chain, moving_chain]."
-            "E.g. to overlay chain C onto chain B, specify: --ncs-chains B C"
-        ),
-    }),
-
-    (("--mapname",), {
-        "required": False,
-        "default": "matchmaps_ncs",
-        "help": "Base filename for the output map files. "
-    })
+    (
+        ("--mtz", "-m"),
+        {
+            "nargs": "*",
+            "required": True,
+            "help": (
+                "MTZ or sfCIF file containing structure factor amplitudes. "
+                "Specified as [filename F SigF] or [filename F]. "
+                "SigF is not necessary if phases are also provided"
+            ),
+        },
+    ),
+    (
+        ("--phases",),
+        {
+            "required": False,
+            "default": None,
+            "help": (
+                "Optional. Column in MTZ/sfCIF file containing phases. "
+                "If phases are not provided, phases will be computed via rigid-body refinement of "
+                "the provided model and structure factor amplitudes."
+            ),
+        },
+    ),
+    (
+        ("--pdb", "-p"),
+        {
+            "required": True,
+            "help": (
+                "Reference PDB or mmCIF. "
+                "If phases are not provided, used for rigid-body refinement of input MTZ/sfCIF to generate phases."
+            ),
+        },
+    ),
+    (
+        ("--ncs-chains", "-n"),
+        {
+            "required": True,
+            "metavar": ("fixed_chain", "moving_chain"),
+            "default": None,
+            "nargs": 2,
+            "help": (
+                "NCS chains to overlay and subtract, specified as [fixed_chain, moving_chain]."
+                "E.g. to overlay chain C onto chain B, specify: --ncs-chains B C"
+            ),
+        },
+    ),
+    (
+        ("--mapname",),
+        {
+            "required": False,
+            "default": "matchmaps_ncs",
+            "help": "Base filename for the output map files. ",
+        },
+    ),
 )
 
-common_args = (
+common_matchmaps_args = (
     # args used by all three utilities
-    (("--ligands", "-l"), {
-        "help": "Any .cif restraint files needed for refinement",
-        "required": False,
-        "default": None,
-        "nargs": "*",
-    }),
+    (
+        ("--ligands", "-l"),
+        {
+            "help": "Any .cif restraint files needed for refinement",
+            "required": False,
+            "default": None,
+            "nargs": "*",
+        },
+    ),
+    (
+        ("--spacing", "-s"),
+        {
+            "help": (
+                "Approximate voxel size in Angstroms for real-space maps. Defaults to 0.5 A. "
+                "Value is approximate because there must be an integer number of voxels along each unit cell dimension"
+            ),
+            "required": False,
+            "default": 0.5,
+            "type": float,
+        },
+    ),
+    (
+        ("--no-bss",),
+        {
+            "help": (
+                "Include this flag to skip bulk solvent scaling in phenix.refine. By default, BSS is included."
+            ),
+            "required": False,
+            "action": "store_true",
+            "default": False,
+        },
+    ),
+    (
+        ("--verbose", "-v"),
+        {
+            "help": "Include this flag to print out scaleit and phenix.refine outputs to the terminal. Useful for troubleshooting, but annoying; defaults to False.",
+            "required": False,
+            "action": "store_true",
+            "default": False,
+        },
+    ),
+    (
+        ("--eff",),
+        {
+            "help": "Custom .eff template for running phenix.refine. ",
+            "required": False,
+            "default": None,
+        },
+    ),
+    (
+        ("--keep-temp-files", "-k"),
+        {
+            "required": False,
+            "default": None,
+            "help": (
+                "Do not delete intermediate matchmaps files, but rather place them in the supplied directory. "
+                "This directory is created as a subdirectory of the supplied output-dir."
+            ),
+        },
+    ),
+    (
+        ("--script",),
+        {
+            "required": False,
+            "default": "run_matchmaps",
+            "help": (
+                "Name for a file {script}.sh which can be run to repeat this command. "
+                "By default, this file is called `run_matchmaps.sh`. "
+                "Note that this file is written out in the current working directory, NOT the input or output directories"
+            ),
+        },
+    ),
+    (
+        ("--phenix-version",),
+        {
+            "required": False,
+            "help": (
+                "Specify phenix version as a string, e.g. '1.20'. "
+                "If omitted, matchmaps will attempt to automatically detect the version in use "
+                "by analyzing the output of phenix.version"
+            ),
+        },
+    ),
+)
 
-    (("--input-dir", "-i"), {
-        "help": "Path to input files. Optional, defaults to './' (current directory)",
-        "required": False,
-        "default": "./",
-    }),
+global_args = (
+    (
+        ("--input-dir", "-i"),
+        {
+            "help": "Path to input files. Optional, defaults to './' (current directory)",
+            "required": False,
+            "default": "./",
+        },
+    ),
+    (
+        ("--output-dir", "-o"),
+        {
+            "help": "Path to which output files should be written. Optional, defaults to './' (current directory)",
+            "required": False,
+            "default": "./",
+        },
+    ),
+    (
+        ("--dmin",),
+        {
+            "help": (
+                "Highest-resolution (in Angstroms) reflections to include in Fourier transform for FloatGrid creation. "
+                "By default, cutoff is the resolution limit of the lower-resolution input MTZ. "
+            ),
+            "required": False,
+            "type": float,
+            "default": None,
+        },
+    ),
+)
 
-    (("--output-dir", "-o"), {
-        "help": "Path to which output files should be written. Optional, defaults to './' (current directory)",
-        "required": False,
-        "default": "./",
-    }),
-
-    (("--spacing", "-s"), {
-        "help": (
-            "Approximate voxel size in Angstroms for real-space maps. Defaults to 0.5 A. "
-            "Value is approximate because there must be an integer number of voxels along each unit cell dimension"
-        ),
-        "required": False,
-        "default": 0.5,
-        "type": float,
-    }),
-
-    (("--dmin",), {
-        "help": (
-            "Highest-resolution (in Angstroms) reflections to include in Fourier transform for FloatGrid creation. "
-            "By default, cutoff is the resolution limit of the lower-resolution input MTZ. "
-        ),
-        "required": False,
-        "type": float,
-        "default": None,
-    }),
-
-    (("--no-bss",), {
-        "help": (
-            "Include this flag to skip bulk solvent scaling in phenix.refine. By default, BSS is included."
-        ),
-        "required": False,
-        "action": "store_true",
-        "default": False,
-    }),
-
-    (("--verbose", "-v"), {
-        "help": "Include this flag to print out scaleit and phenix.refine outputs to the terminal. Useful for troubleshooting, but annoying; defaults to False.",
-        "required": False,
-        "action": "store_true",
-        "default": False,
-    }),
-
-    (("--eff",), {
-        "help": "Custom .eff template for running phenix.refine. ",
-        "required": False,
-        "default": None,
-    }),
-
-    (("--keep-temp-files", "-k"), {
-        "required": False,
-        "default": None,
-        "help": (
-            "Do not delete intermediate matchmaps files, but rather place them in the supplied directory. "
-            "This directory is created as a subdirectory of the supplied output-dir."
-        )}),
-
-    (("--script",), {
-        "required": False,
-        "default": "run_matchmaps",
-        "help": (
-            "Name for a file {script}.sh which can be run to repeat this command. "
-            "By default, this file is called `run_matchmaps.sh`. "
-            "Note that this file is written out in the current working directory, NOT the input or output directories"
-        )
-    }),
-
-    (("--phenix-version",), {
-        "required": False,
-        "help": (
-            "Specify phenix version as a string, e.g. '1.20'. "
-            "If omitted, matchmaps will attempt to automatically detect the version in use "
-            "by analyzing the output of phenix.version"
-        )
-    }),
+diagnose_args = (
+    # args used by only matchmaps.diagnose
+    # these differ from the standard mtzoff/mtzon because the third argument is phase, not SigF!
+    (
+        ("--mtzoff", "-f"),
+        {
+            "nargs": 3,
+            "metavar": ("mtzfileoff", "Foff", "Phioff"),
+            "required": True,
+            "help": (
+                "MTZ or sfCIF containing off/apo/ground/dark state data. "
+                "Specified as [filename F Phi] (no need for SigF here!)"
+            ),
+        },
+    ),
+    (
+        ("--mtzon", "-n"),
+        {
+            "nargs": 3,
+            "metavar": ("mtzfileon", "Fon", "Phioff"),
+            "required": True,
+            "help": (
+                "MTZ or sfCIF containing on/bound/excited/bright state data. "
+                "Specified as [filename F Phi] (no need for SigF here!)"
+            ),
+        },
+    ),
+    (
+        ("--filename",),
+        {
+            "required": False,
+            "help": "Base filename for the plot; should have a file extension compatible with plt.savefig",
+        },
+    ),
+    (
+        ("--title", "-t"),
+        {
+            "required": False,
+            "default": "Produced by matchmaps.diagnose",
+            "help": "Title for the plot",
+        },
+    ),
 )

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -34,7 +34,7 @@ def compute_mr_difference_map(
     Fon : str,
     SigFon : str,
     ligands: list = None,
-    dmin : int = None,
+    dmin : float = None,
     spacing = 0.5,
     on_as_stationary = False,
     input_dir = Path("."),

--- a/src/matchmaps/_compute_ncs_diff.py
+++ b/src/matchmaps/_compute_ncs_diff.py
@@ -33,7 +33,7 @@ def compute_ncs_difference_map(
     Phi : str = None,
     ligands : list = None,
     name : str = None,
-    dmin : int = None,
+    dmin : float = None,
     spacing = 0.5,
     input_dir=Path("."),
     output_dir=Path("."),

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -32,7 +32,7 @@ def compute_realspace_difference_map(
         Fon: str,
         SigFon: str,
         ligands: list = None,
-        dmin: int = None,
+        dmin: float = None,
         spacing=0.5,
         on_as_stationary: bool = False,
         input_dir=Path("."),

--- a/src/matchmaps/_diagnostic_plots.py
+++ b/src/matchmaps/_diagnostic_plots.py
@@ -8,10 +8,13 @@ import matplotlib.pyplot as plt
 from matplotlib import rcParams
 
 from matchmaps._parsers import matchmaps_diagnose_parser
+from matchmaps._utils import _validate_inputs
+
+
 # to do list:
-# [  ] write function for making plot
+# [ x ] write function for making plot
 # [  ] write main function which directs command-line arguments into the plot
-# [  ] write argument parser (in the _parsers and _args files), reusing code where possible
+# [ x ] write argument parser (in the _parsers and _args files), reusing code where possible
 # [  ] write a useful docstring
 # [  ] make sure matchmaps functions aren't broken!
 
@@ -122,11 +125,30 @@ def cc_datasets(
 
 def main():
 
-    args =
+    args = matchmaps_diagnose_parser.parse_args()
 
-    print("entered diagnostic plots")
+    (input_dir, output_dir, _, mtzoff, mtzon) = _validate_inputs(
+        args.input_dir,
+        args.output_dir,
+        None,
+        args.mtzoff[0],
+        args.mtzon[0],
+    )
 
-    compute_diagnostic_plots()
+    compute_diagnostic_plots(
+        mtzoff=mtzoff,
+        mtzon=mtzon,
+        Foff=args.mtzoff[1],
+        Phioff=args.mtzoff[2],
+        Fon=args.mtzon[1],
+        Phion=args.mtzon[2],
+        input_dir=input_dir,
+        output_dir=output_dir,
+        filename=args.filename,
+        bins=args.bins,
+        dmin=args.dmin,
+        title=args.title,
+    )
 
     return
 

--- a/src/matchmaps/_diagnostic_plots.py
+++ b/src/matchmaps/_diagnostic_plots.py
@@ -1,0 +1,128 @@
+"""Make diagnostic plots similar to those in Figure 1 of the MatchMaps paper"""
+
+from pathlib import Path
+
+import reciprocalspaceship as rs
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import rcParams
+
+# to do list:
+# [  ] write function for making plot
+# [  ] write main function which directs command-line arguments into the plot
+# [  ] write argument parser (in the _parsers and _args files), reusing code where possible
+# [  ] write a useful docstring
+# [  ] make sure matchmaps functions aren't broken!
+
+
+def compute_diagnostic_plots(
+    mtzoff: Path,
+    mtzon: Path,
+    Foff: str,
+    Fon: str,
+    Phioff: str,
+    Phion: str,
+    bins: int = 15,
+    dmin: float = None,
+    input_dir=Path("."),
+    output_dir=Path("."),
+    filename=None,
+):
+    rcParams.update({"figure.autolayout": True})
+    rcParams.update({"font.size": 16})
+
+    offmtz = rs.read_mtz(str(input_dir / mtzoff))
+    onmtz = rs.read_mtz(str(input_dir / mtzon))
+
+    offmtz.canonicalize_phases(inplace=True)
+    onmtz.canonicalize_phases(inplace=True)
+
+    mtz = offmtz.merge(onmtz, on=["H", "K", "L"], suffixes=("_off", "_on"))
+
+    mtz = mtz.label_centrics(inplace=True).query("not CENTRIC").dropna()
+
+    if dmin:
+        mtz.compute_dHKL(inplace=True)
+        mtz = mtz.loc[mtz.dHKL >= dmin]
+
+    for newname, oldname in zip(
+        ("cosphi_off", "cosphi_on"), (f"{Phioff}_off", f"{Phion}_on")
+    ):
+
+        mtz[newname] = np.cos(mtz[oldname] * np.pi / 180)
+
+    plt.figure(figsize=(8, 7))
+    plt.grid(linestyle="--")
+    plt.hlines(0, 0, bins-1, color='gray', linestyle='-')
+    plt.xlabel(r"Resolution bins ($\AA$)")
+    plt.ylabel(r"$CC_{1/2}$")
+
+    edges = cc_datasets(
+        mtz,
+        "cosphi_off",
+        "cosphi_on",
+        marker="o",
+        color="#1f77b4",
+        linestyle="-",
+        label="cos(Phase) correlation",
+        bins=bins,
+    )
+    cc_datasets(
+        mtz,
+        f"{Foff}_off",
+        f"{Fon}_on",
+        bins=edges,
+        color="#be4f30",
+        marker="o",
+        linestyle="--",
+        label="Amplitude correlation",
+        return_edges=False
+    )
+
+    plt.legend(loc="upper right")
+    plt.show()
+    return mtz
+
+
+def cc_datasets(
+    mtz,
+    column1,
+    column2,
+    bins=15,
+    return_edges=True,
+    method="spearman",
+    label=None,
+    **kwargs,
+):
+    mtz, labels, edges = mtz.assign_resolution_bins(
+        bins, return_labels=True, return_edges=True
+    )
+    nbins = len(edges) - 1
+    grouper = mtz.groupby(["bin"])[[column1, column2]]
+
+    result = (
+        grouper.corr(method=method)
+        .unstack()[(column1, column2)]
+        .to_frame()
+        .reset_index()
+    )
+    plt.plot(result.bin, result[column1], label=label, **kwargs)
+    plt.xticks(range(nbins), labels, rotation=45, ha="right", rotation_mode="anchor")
+
+    if return_edges:
+        return edges
+    else:
+        return
+
+
+def main():
+
+    print("entered diagnostic plots")
+
+    compute_diagnostic_plots()
+
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/src/matchmaps/_diagnostic_plots.py
+++ b/src/matchmaps/_diagnostic_plots.py
@@ -7,6 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import rcParams
 
+from matchmaps._parsers import matchmaps_diagnose_parser
 # to do list:
 # [  ] write function for making plot
 # [  ] write main function which directs command-line arguments into the plot
@@ -120,6 +121,8 @@ def cc_datasets(
 
 
 def main():
+
+    args =
 
     print("entered diagnostic plots")
 

--- a/src/matchmaps/_diagnostic_plots.py
+++ b/src/matchmaps/_diagnostic_plots.py
@@ -27,6 +27,7 @@ def compute_diagnostic_plots(
     input_dir=Path("."),
     output_dir=Path("."),
     filename=None,
+    title = 'Produced by matchmaps.diagnose',
 ):
     rcParams.update({"figure.autolayout": True})
     rcParams.update({"font.size": 16})
@@ -53,6 +54,7 @@ def compute_diagnostic_plots(
 
     plt.figure(figsize=(8, 7))
     plt.grid(linestyle="--")
+    plt.title(title)
     plt.hlines(0, 0, bins-1, color='gray', linestyle='-')
     plt.xlabel(r"Resolution bins ($\AA$)")
     plt.ylabel(r"$CC_{1/2}$")
@@ -80,6 +82,8 @@ def compute_diagnostic_plots(
     )
 
     plt.legend(loc="upper right")
+    if filename:
+        plt.savefig(output_dir / filename, dpi=600)
     plt.show()
     return mtz
 

--- a/src/matchmaps/_parsers.py
+++ b/src/matchmaps/_parsers.py
@@ -4,14 +4,20 @@ from matchmaps._args import (
     matchmaps_description,
     matchmaps_mr_description,
     matchmaps_ncs_description,
+    matchmaps_diagnose_description,
     base_and_mr_args,
     ncs_args,
-    common_args
+    common_matchmaps_args,
+    global_args,
+    diagnose_args
 )
 
 matchmaps_parser = argparse.ArgumentParser(description=matchmaps_description)
 matchmaps_mr_parser = argparse.ArgumentParser(description=matchmaps_mr_description)
 matchmaps_ncs_parser = argparse.ArgumentParser(description=matchmaps_ncs_description)
+
+matchmaps_diagnose_parser = argparse.ArgumentParser(description=matchmaps_diagnose_description)
+
 
 for args, kwargs in base_and_mr_args:
     matchmaps_parser.add_argument(*args, **kwargs)
@@ -20,8 +26,18 @@ for args, kwargs in base_and_mr_args:
 for args, kwargs in ncs_args:
     matchmaps_ncs_parser.add_argument(*args, **kwargs)
 
-for args, kwargs in common_args:
+for args, kwargs in diagnose_args:
+    matchmaps_diagnose_parser.add_argument(*args, **kwargs)
+
+for args, kwargs in common_matchmaps_args:
     matchmaps_parser.add_argument(*args, **kwargs)
     matchmaps_mr_parser.add_argument(*args, **kwargs)
     matchmaps_ncs_parser.add_argument(*args, **kwargs)
+
+for args, kwargs in global_args:
+    matchmaps_parser.add_argument(*args, **kwargs)
+    matchmaps_mr_parser.add_argument(*args, **kwargs)
+    matchmaps_ncs_parser.add_argument(*args, **kwargs)
+    matchmaps_diagnose_parser.add_argument(*args, **kwargs)
+
 


### PR DESCRIPTION
This PR will add the command-line utility `matchmaps.diagnose`, which produces a plot analogous to Figure 1a in the matchmaps paper. This plot helps a user determine how poor the isomorphism is between two datasets, which can in turn help decide between using an isomorphous different map and matchmaps.

Doeke suggested this; see #69 