### PR TITLE
Patch bug with gemmi >= 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "tqdm",
     "reciprocalspaceship>=1.0.1",
     "rs-booster>=0.1.2",
-    "gemmi"
+    "gemmi>=0.7.1"
 ]
 
 # extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "tqdm",
     "reciprocalspaceship>=1.0.1",
     "rs-booster>=0.1.2",
-    "gemmi>=0.7.1"
+    "gemmi>=0.7.0"
 ]
 
 # extras

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -551,7 +551,7 @@ def align_grids_from_model_transform(
         tr=transform,
         dest_model=structure1[0],  # dest_model,
         radius=radius,
-        order=2,
+        order=1,
     )
 
     return grid2_out
@@ -596,7 +596,7 @@ def _ncs_align_and_subtract(
         tr=sup.transform.inverse(),
         dest_model=pdb[0],
         radius=8,
-        order=2,
+        order=1,
     )
 
     model = gemmi.Model("dummy model")


### PR DESCRIPTION
As mentioned in #71 , there is a bug which makes `matchmaps` incompatible with `gemmi>=0.7.0`.

The gemmi function `interpolate_grid_of_aligned_model2` is used by `matchmaps` to align two maps based on some transformation, and it ensures that the voxel frames match up after the transformation. Previously (`gemmi<=0.6.7`) linear interpolation could be specified with the argument `order=2`. However, the call signature for this function was updated in the release of `0.7.0` (see https://github.com/project-gemmi/gemmi/releases/tag/v0.7.0), specifically:
> unified API of Grid interpolation functions. They now have parameter order that can be 0 (nearest value), 1 (linear interpolation), or 3 (cubic). In C++ there are also functions such as trilinear_interpolation() to ensure no overhead.

This PR changes calls to `interpolate_grid_of_aligned_model2` to specific `order=1` to get the desired linear interpolation.

This PR also updates the gemmi dependency to `>=0.7.0`. This is probably overkill, because the gemmi version tends to be determined by the requirements of reciprocalspaceship, but I still wanted to include it here explicitly.

## Should other interpolations be supported?

No.

It would be possible to add support for this, of course. However, the gemmi docs are pretty specific that the tricubic interpolation is likely to amplify noise, which I don't want. I won't know why "nearest value" interpolation could possibly be desired.

If a user wants to fiddle with this type of thing, I think that can be accomplished via the `--spacing` parameter.