### PR TITLE
Add support for python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         platform: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U pip setuptools
           python -m pip install -e .[test]
 
       - name: Test


### PR DESCRIPTION
While setting up unit tests, I had issues with python 3.12 and reciprocalspaceship. I solved this problem by temporarily dropping support for python 3.12 while I got things sorted out, but now I would like to add it back.