### PR TITLE
Upper bound dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "matchmaps"
 # versioning through releases
 description = "Make unbiased difference maps even for non-isomorphous inputs"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9, <=3.12"
 license = { text = "BSD 3-Clause License" }
 authors = [
     { email = "debrookner@gmail.com", name = "Dennis Brookner" },
@@ -27,11 +27,11 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "numpy",
+    "numpy>=2, <=2.1",
     "tqdm",
-    "reciprocalspaceship>=1.0.4",
-    "rs-booster>=0.1.2",
-    "gemmi>=0.7.0"
+    "reciprocalspaceship>=1.0.4, <=1.0.4",
+    "rs-booster>=0.1.2, <= 0.1.2",
+    "gemmi>=0.7.0, <=0.7.2"
 ]
 
 # extras

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{38,39,310,311}-{linux,macos,windows}
 isolated_build = true
 toxworkdir=/tmp/.tox
 


### PR DESCRIPTION
Add upper bounds to the version dependencies of numpy, reciprocalspaceship, rs-booster, and gemmi. This will trigger the renovate bot to update these bounds, as desired.