### PR TITLE
Link to paper on home page and other minor updates

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,6 +1,6 @@
 # About the `matchmaps` algorithm
 
-If you want to learn more about the idea behind `matchmaps`, along with some examples, please check out paper in the Journal of Applied Crystallography!
+If you want to learn more about the idea behind `matchmaps`, along with some examples, please check out our paper in the Journal of Applied Crystallography!
 
 > [MatchMaps: non-isomorphous difference maps for X-ray crystallography](https://journals.iucr.org/j/issues/2024/03/00/ei5112/index.html)
 

--- a/docs/diagnose.md
+++ b/docs/diagnose.md
@@ -1,13 +1,18 @@
 # Should I use `matchmaps`? Diagnosing non-isomorphism
 
-You have two crystallographic datasets that you'd like to compare with an Fo-Fo difference map. Should you use `matchmaps`, or will an isomorphous difference map do the trick? To help answer this question, `matchmaps` provides the utility `matchmaps.diagnose`, which creates a plot similar to the following (Figure 1a from the [MatchMaps paper](https://journals.iucr.org/j/issues/2024/03/00/ei5112/index.html))
+You have two crystallographic datasets that you'd like to compare with an $F_oF_o$ difference map. Should you use `matchmaps`, or will an isomorphous difference map do the trick? To help answer this question, `matchmaps` provides the utility `matchmaps.diagnose`, which creates a plot similar to the following (Figure 1a from the [MatchMaps paper](https://journals.iucr.org/j/issues/2024/03/00/ei5112/index.html))
 
 ![Figure 1a: resolution dependence of inter-dataset correlation](images/figure.jpg)
 
 ## Interpreting this plot
 
 The plot above shows three curves for each pair of datasets; each curve represents a form of resolution-dependent correlation between the datasets.
-Two of the curves report $CC_{1/2}$ between structure factor amplitudes and $cos(\textrm{structure factor phases}$), and the third shows the figure of merit for structure factor phases. `matchmaps.diagnose` omits the figure-of-merit caculation and just shows the two $CC_{1/2}$ curves.
+Two of the curves report $CC_{1/2}$ between structure factor amplitudes and $cos(\textrm{structure factor phases}$), and the third shows the figure of merit for structure factor phases. 
+
+```{eval-rst}
+.. note::
+    `matchmaps.diagnose` omits the figure-of-merit caculation and just shows the two $CC_{1/2}$ curves.
+```
 
 The worse the isomorphism between your datasets, the more quickly these correlations will drop off with resolution. The above plot shows two very extreme examples. The isomorphous datasets (PDB IDs 1RX2 and 1RX1) correlate quite well even out to the highest-resolution bin; these datasets can be compared effectively with an isomorphous difference map.
 
@@ -23,10 +28,8 @@ These plots compare the correlation for both structure factor amplitudes and str
 
 ## Using `matchmaps.diagnose`
 
-```{eval-rst}
-.. note::
-    Note that, unlike the main `matchmaps` utilities, `matchmaps.diagnose` does *not* require the PHENIX or CCP4 external dependencies. Just a quick `pip install matchmaps`, and you're ready to go!
-```
+Unlike the main `matchmaps` utilities, `matchmaps.diagnose` does *not* require the PHENIX or CCP4 external dependencies. Just a quick `pip install matchmaps`, and you're ready to go!
+
 The simplest usage of `matchmaps.diagnose` is to just supply your two input files, along with the names for the structure factor amplitudes and phases in each dataset. Make sure you're including *observed* structure factor amplitudes!
 
 ```bash
@@ -35,6 +38,9 @@ matchmaps.diagnose \
     --mtzon  on.mtz  FP PHIC
 ```
 
-Make sure that you're supplying phases here! This syntax is similar to that of the main `matchmaps` utilites, except that in those cases, you supply structure factor amplitudes and *uncertainties*.
+```{eval-rst}
+.. note::
+    Make sure that you're supplying phases here! This syntax is similar to that of the main `matchmaps` utilites, except that in those cases, you supply structure factor amplitudes and *uncertainties*.
+```
 
-Full documentation of the command-line interface for `matchmaps.diagnose` can be found on the [CLI page](cli.md#matchmaps-diagnose)
+Full documentation of the command-line interface for `matchmaps.diagnose` can be found on the [CLI page](cli.md#matchmaps-diagnose). If you have any feature requests, please [let me know](https://github.com/rs-station/matchmaps/issues)! This utility was suggested by a user, and I want it to contain as much functionality as is useful.

--- a/docs/diagnose.md
+++ b/docs/diagnose.md
@@ -7,7 +7,7 @@ You have two crystallographic datasets that you'd like to compare with an $F_oF_
 ## Interpreting this plot
 
 The plot above shows three curves for each pair of datasets; each curve represents a form of resolution-dependent correlation between the datasets.
-Two of the curves report $CC_{1/2}$ between structure factor amplitudes and $cos(\textrm{structure factor phases}$), and the third shows the figure of merit for structure factor phases. 
+Two of the curves report $CC_{1/2}$ between structure factor amplitudes and $cos(\textrm{structure factor phases}$), and the third shows the figure of merit for structure factor phases.
 
 ```{eval-rst}
 .. note::

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,19 +4,23 @@ Welcome to the docs for `matchmaps`, a python package for aligning and subtracti
 
 The [quickstart guide](quickstart.md) contains installation instructions and sample usage of the basic `matchmaps` utility, along with other useful tips.
 
-If you'd like to learn more about `matchmaps`, you can find our exploration of the package [here](about.md). For even more information, and see the package in action, please check out our pre-print!
-> [MatchMaps: Non-isomorphous difference maps for X-ray crystallography](https://www.biorxiv.org/content/10.1101/2023.09.01.555333v2.full.pdf+html)
+If you'd like to learn more about `matchmaps`, you can find our exploration of the package [here](about.md). For even more information, and see the package in action, please check out our paper in the Journal of Applied Crystallography!
+
+> [MatchMaps: non-isomorphous difference maps for X-ray crystallography](https://journals.iucr.org/j/issues/2024/03/00/ei5112/index.html)
 
 This software is part of the [Reciprocal Space Station](https://rs-station.github.io/) family of open-source crystallography software and was conceived in [Doeke Hekstra's Lab](https://hekstralab.fas.harvard.edu/) at Harvard by [Dennis Brookner](https://dennisbrookner.github.io/)
 
 ## The `matchmaps` functions in brief
 
-`matchmaps` consists of three command-line utilities. A walkthrough of the core utility can be found [here](quickstart.md), and all options for all three utilites are documented [here](cli.md). All three utilities produce a real-space difference map and require a single starting model for phasing, but differ in the types of reflection data they require. Briefly:
+`matchmaps` consists of three main command-line utilities. A walkthrough of the core utility can be found [here](quickstart.md), and all options for all three utilites are documented [here](cli.md). All three utilities produce a real-space difference map and require a single starting model for phasing, but differ in the types of reflection data they require. Briefly:
 
  - **`matchmaps`** takes in two mtzs containing similar data and which are nearly isomorphous and computes an unbiased real-space difference map between them
  - **`matchmaps.mr`** takes in two mtzs containing similar data but which are in different spacegroups (or the same spacegroup but different crystal packing) and computes an unbiased real-space difference map between them.
  - **`matchmaps.ncs`** takes in a single mtz and computes an internal difference map across a defined non-crystallographic symmetry present in the data.
 
+Additionally, `matchmaps` provides a utility called `matchmaps.diagnose`, which will produce a plot to help evaluate the isomorphism (or lack thereof!) between a pair of datasets. This is described in more detail [here](diagnose.md).
+
+Last and also least, you can run `matchmaps.version` to check which version of `matchmaps` is installed.
 
 ```{eval-rst}
 .. toctree::


### PR DESCRIPTION
Doeke pointed out (#91) that the documentation homepage still linked to the pre-print! This PR fixes that, and also
 - mentions the `matchmaps.diagnose` (and `matchmaps.version`) utilities on the homepage, for completeness
 - touches up the language on the `diagnose.md` page