### PR TITLE
Change string concatenation to use pathlib

### DIFF
--- a/src/matchmaps/_phenix_utils.py
+++ b/src/matchmaps/_phenix_utils.py
@@ -155,7 +155,7 @@ def rigid_body_refinement_wrapper(
     if eff is None:
         eff_contents = _auto_eff_refinement_template(phenix_style=phenix_style)
     else:
-        with open(input_dir + eff) as file:
+        with open(input_dir / eff) as file:
             eff_contents = file.read()
 
     if (off_labels is None) or mr_on:


### PR DESCRIPTION
pathlib objects cleverly override the `/` operator to mean "concatentate these file paths"; however, this means that pathlib objects *cannot* be concatenated by a `+` like you would with a string.

This bug persisted because it lived in a rarely-used `else` block.